### PR TITLE
Add compacted conversation context window

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The repository currently ships with:
 - Implemented: trigger-based named-window screenshot capture for Gemini input on macOS
 - Implemented: AivisSpeech synthesis over the local HTTP API
 - Implemented: sentence-by-sentence TTS playback with one-sentence-ahead prefetch
+- Implemented: bounded LLM request compaction with an earlier-conversation summary plus a recent raw-message window
 - Implemented: structured JSON logging and in-memory stage latency metrics
 - Implemented: unit tests for settings, device resolution, utterance accumulation, provider payload/selection logic, queue behavior, and orchestration
 - Not implemented yet: streaming partial STT / LLM / TTS
@@ -108,6 +109,7 @@ Application-audio notes:
 Screen-capture notes:
 
 - screen capture is request-scoped, not persistent session history
+- older user/assistant turns are compacted into one system summary when the request window grows past the configured raw-message count
 - capture is triggered only when the normalized user utterance contains one of the configured trigger phrases
 - the current implementation resolves the first on-screen window whose title or owner name matches `VOCALIVE_SCREEN_WINDOW_NAME`
 - captured screenshots are downscaled so the longest edge is at most `1280px` before they are attached to Gemini; set `VOCALIVE_SCREEN_RESIZE_MAX_EDGE_PX` empty to disable that
@@ -171,6 +173,8 @@ All runtime configuration is environment-driven.
 | `VOCALIVE_TTS_PROVIDER` | `mock` | TTS adapter; accepts `aivis` and aliases such as `aivis speech` |
 | `VOCALIVE_OUTPUT_PROVIDER` | `memory` | `memory` or `speaker` |
 | `VOCALIVE_CONVERSATION_LANGUAGE` | `ja` | Per-turn language instruction injected before the LLM call; set empty to disable |
+| `VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT` | `8` | Number of recent user/assistant messages kept verbatim in Gemini requests before older dialogue is compacted |
+| `VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS` | `1200` | Character budget for the earlier-conversation summary injected ahead of the recent raw-message window |
 | `VOCALIVE_GEMINI_API_KEY` | unset | Gemini API key; `GEMINI_API_KEY` is also accepted |
 | `VOCALIVE_GEMINI_MODEL` | `gemini-2.5-flash` | Gemini model name used for `generateContent` |
 | `VOCALIVE_GEMINI_TIMEOUT_SECONDS` | `30` | Gemini HTTP timeout |
@@ -202,6 +206,7 @@ Current provider support:
 - `gemini` uses the Gemini `generateContent` API over HTTPS; the default config sets `thinkingBudget=0` to reduce latency
 - optional application-audio capture resolves one running macOS app, segments its audio into utterances, and by default submits those transcripts as labeled application context without immediate assistant replies
 - optional screen capture resolves a named on-screen window on macOS and attaches one PNG of that window to the current Gemini turn when a trigger phrase matches
+- older user/assistant dialogue is compacted into one bounded system summary before Gemini requests so long sessions do not resend the entire raw conversation every turn
 - `aivis` uses the local AivisSpeech engine API and resolves a style id from `/speakers` when needed
 - `speaker` output plays synthesized audio through the configured external command
 - provider names are normalized case-insensitively, so values such as `Moonshine Voice` and `Aivis Speech` resolve to the supported adapters

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,7 @@ shared pipeline
   -> STT adapter
   -> append user or application-context message to session
   -> optionally capture the configured window for the current turn when a trigger phrase matches
+  -> compact older user/assistant history into one bounded summary while keeping a recent raw-message window
   -> prepend conversation-language system instruction when configured
   -> LLM adapter
   -> split assistant text into sentence-sized chunks
@@ -119,7 +120,7 @@ This prevents unbounded backlog growth and avoids finishing obsolete replies aft
 - user messages are appended after STT completes
 - application-audio transcripts are appended after STT completes as labeled `application` context messages, not user messages
 - in the default `context_only` mode, those application messages do not immediately trigger LLM/TTS; they are consumed on the next user-driven turn
-- the LLM receives a snapshot of the current session plus an optional conversation-language system instruction
+- the LLM receives a compacted session view: recent user/assistant raw messages plus one bounded earlier-conversation summary and an optional conversation-language system instruction
 - screen captures are request-scoped extras for the current user turn only and are not persisted in session history
 - assistant messages are appended only after the full reply has been synthesized and played
 - interrupted assistant replies are therefore not committed to session history

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,6 +43,7 @@ The current entry point is `src/vocalive/main.py`.
 - the stdin shell waits for the orchestrator to become idle, then prints the last committed assistant message
 - the microphone loop keeps reading while the assistant is speaking, so speech onset can stop stale playback immediately
 - in `respond` mode, the application-audio loop also keeps reading while the assistant is speaking, so new app dialogue can stop stale playback immediately
+- older user/assistant turns are compacted into one bounded summary before Gemini requests once the configured recent raw-message window is exceeded
 - `VOCALIVE_MIC_DEVICE=external` forces selection of a connected headset-like external mic
 - when `VOCALIVE_MIC_DEVICE` is unset and `VOCALIVE_MIC_PREFER_EXTERNAL=true`, VocaLive prefers a connected external mic over a built-in default input
 - the microphone path uses local RMS thresholding plus silence timing, not a production VAD
@@ -95,6 +96,8 @@ Runtime settings are loaded from `AppSettings.from_env()` in `src/vocalive/confi
 | `VOCALIVE_TTS_PROVIDER` | `mock` | `aivis` is supported; aliases such as `aivis speech` are accepted |
 | `VOCALIVE_OUTPUT_PROVIDER` | `memory` | `memory` or `speaker` |
 | `VOCALIVE_CONVERSATION_LANGUAGE` | `ja` | Injects a per-turn language instruction before the LLM call; set empty to disable |
+| `VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT` | `8` | Number of recent user/assistant messages kept raw in LLM requests before older conversation is compacted |
+| `VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS` | `1200` | Character budget for the bounded earlier-conversation summary inserted ahead of the recent raw window |
 | `VOCALIVE_GEMINI_API_KEY` | unset | Required for `gemini`; `GEMINI_API_KEY` is also accepted |
 | `VOCALIVE_GEMINI_MODEL` | `gemini-2.5-flash` | Model name passed to `generateContent` |
 | `VOCALIVE_GEMINI_TIMEOUT_SECONDS` | `30` | Gemini HTTP timeout |

--- a/src/vocalive/config/settings.py
+++ b/src/vocalive/config/settings.py
@@ -142,6 +142,12 @@ class ConversationSettings:
 
 
 @dataclass
+class ContextSettings:
+    recent_message_count: int = 8
+    conversation_summary_max_chars: int = 1200
+
+
+@dataclass
 class MoonshineSettings:
     model_name: str = "base"
 
@@ -164,6 +170,7 @@ class AppSettings:
     tts_provider: str = "mock"
     queue: QueueSettings = field(default_factory=QueueSettings)
     conversation: ConversationSettings = field(default_factory=ConversationSettings)
+    context: ContextSettings = field(default_factory=ContextSettings)
     input: InputSettings = field(default_factory=InputSettings)
     application_audio: ApplicationAudioSettings = field(default_factory=ApplicationAudioSettings)
     output: OutputSettings = field(default_factory=OutputSettings)
@@ -195,6 +202,16 @@ class AppSettings:
                 language=_read_optional_str_with_default(
                     "VOCALIVE_CONVERSATION_LANGUAGE",
                     default="ja",
+                ),
+            ),
+            context=ContextSettings(
+                recent_message_count=_read_int(
+                    "VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT",
+                    default=8,
+                ),
+                conversation_summary_max_chars=_read_int(
+                    "VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS",
+                    default=1200,
                 ),
             ),
             input=InputSettings(

--- a/src/vocalive/pipeline/context.py
+++ b/src/vocalive/pipeline/context.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from vocalive.models import ConversationMessage
+
+
+_SUMMARY_ROLE_LABELS = {
+    "user": "User",
+    "assistant": "Assistant",
+}
+_OMITTED_LINE = "- Earlier summarized turns omitted for brevity."
+
+
+def build_compacted_messages(
+    messages: tuple[ConversationMessage, ...],
+    *,
+    recent_message_count: int,
+    conversation_summary_max_chars: int,
+) -> tuple[ConversationMessage, ...]:
+    recent_indexes = _select_recent_conversation_indexes(
+        messages,
+        recent_message_count=max(0, recent_message_count),
+    )
+    older_conversation_messages: list[ConversationMessage] = []
+    compacted_messages: list[ConversationMessage] = []
+
+    for index, message in enumerate(messages):
+        if (
+            message.role in {"user", "assistant"}
+            and index not in recent_indexes
+        ):
+            older_conversation_messages.append(message)
+            continue
+        compacted_messages.append(message)
+
+    summary = _build_conversation_summary(
+        older_conversation_messages,
+        max_chars=conversation_summary_max_chars,
+    )
+    if summary is None:
+        return tuple(compacted_messages)
+    return (
+        ConversationMessage(role="system", content=summary),
+        *compacted_messages,
+    )
+
+
+def _select_recent_conversation_indexes(
+    messages: tuple[ConversationMessage, ...],
+    *,
+    recent_message_count: int,
+) -> set[int]:
+    if recent_message_count <= 0:
+        return set()
+    recent_indexes: list[int] = []
+    for index in range(len(messages) - 1, -1, -1):
+        if messages[index].role not in {"user", "assistant"}:
+            continue
+        recent_indexes.append(index)
+        if len(recent_indexes) >= recent_message_count:
+            break
+    return set(recent_indexes)
+
+
+def _build_conversation_summary(
+    messages: list[ConversationMessage],
+    *,
+    max_chars: int,
+) -> str | None:
+    if max_chars <= 0 or not messages:
+        return None
+    header = "Earlier conversation summary:"
+    line_char_limit = max(32, min(120, max_chars // 4))
+    lines = [
+        _format_summary_line(message, max_chars=line_char_limit)
+        for message in messages
+    ]
+    compacted_lines = _fit_summary_lines(lines, header=header, max_chars=max_chars)
+    if not compacted_lines:
+        return None
+    return header + "\n" + "\n".join(compacted_lines)
+
+
+def _fit_summary_lines(
+    lines: list[str],
+    *,
+    header: str,
+    max_chars: int,
+) -> list[str]:
+    if not lines:
+        return []
+    if len(_render_summary(header, lines)) <= max_chars:
+        return lines
+
+    head_lines = lines[:2]
+    if len(_render_summary(header, head_lines)) > max_chars:
+        return [_trim_line(lines[-1], max_chars=max(16, max_chars - len(header) - 1))]
+
+    tail_lines: list[str] = []
+    remaining_lines = lines[2:]
+    for line in reversed(remaining_lines):
+        candidate_tail = [line, *tail_lines]
+        candidate_lines = head_lines + [_OMITTED_LINE] + candidate_tail
+        if len(_render_summary(header, candidate_lines)) > max_chars:
+            continue
+        tail_lines = candidate_tail
+    if len(head_lines) + len(tail_lines) >= len(lines):
+        return head_lines + tail_lines
+    return head_lines + [_OMITTED_LINE] + tail_lines
+
+
+def _format_summary_line(message: ConversationMessage, *, max_chars: int) -> str:
+    role_label = _SUMMARY_ROLE_LABELS.get(message.role, message.role.title())
+    content = " ".join(message.content.split())
+    return f"- {role_label}: {_trim_line(content, max_chars=max_chars)}"
+
+
+def _trim_line(value: str, *, max_chars: int) -> str:
+    if max_chars <= 1 or len(value) <= max_chars:
+        return value[:max_chars]
+    return value[: max_chars - 1].rstrip() + "…"
+
+
+def _render_summary(header: str, lines: list[str]) -> str:
+    return header + "\n" + "\n".join(lines)

--- a/src/vocalive/pipeline/orchestrator.py
+++ b/src/vocalive/pipeline/orchestrator.py
@@ -20,6 +20,7 @@ from vocalive.models import (
     SynthesizedSpeech,
     TurnContext,
 )
+from vocalive.pipeline.context import build_compacted_messages
 from vocalive.pipeline.interruption import (
     CancellationToken,
     InterruptionController,
@@ -359,7 +360,15 @@ class ConversationOrchestrator:
         )
 
     def _build_request_messages(self, conversation_language: str | None) -> tuple[ConversationMessage, ...]:
-        messages = list(self.session.snapshot())
+        messages = list(
+            build_compacted_messages(
+                self.session.snapshot(),
+                recent_message_count=self.settings.context.recent_message_count,
+                conversation_summary_max_chars=(
+                    self.settings.context.conversation_summary_max_chars
+                ),
+            )
+        )
         language_instruction = _build_conversation_language_instruction(conversation_language)
         if language_instruction is not None:
             messages.insert(0, ConversationMessage(role="system", content=language_instruction))

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -18,6 +18,7 @@ from vocalive.config.settings import (
     AppSettings,
     ApplicationAudioMode,
     ApplicationAudioSettings,
+    ContextSettings,
     QueueSettings,
     QueueOverflowStrategy,
     ScreenCaptureSettings,
@@ -268,6 +269,51 @@ class ConversationOrchestratorTests(unittest.IsolatedAsyncioTestCase):
                 ),
                 ("user", "hello"),
             ],
+        )
+
+    async def test_long_conversation_is_compacted_into_summary_plus_recent_window(self) -> None:
+        language_model = CapturingLanguageModel()
+        orchestrator = ConversationOrchestrator(
+            settings=AppSettings(
+                session_id="test-session",
+                queue=QueueSettings(
+                    ingress_maxsize=4,
+                    overflow_strategy=QueueOverflowStrategy.DROP_OLDEST,
+                ),
+                context=ContextSettings(
+                    recent_message_count=1,
+                    conversation_summary_max_chars=220,
+                ),
+            ),
+            stt_engine=MockSpeechToTextEngine(),
+            language_model=language_model,
+            tts_engine=MockTextToSpeechEngine(delay_seconds=0.0),
+            audio_output=MemoryAudioOutput(),
+            metrics=InMemoryMetricsRecorder(),
+        )
+        await orchestrator.start()
+        try:
+            accepted = await orchestrator.submit_utterance(AudioSegment.from_text("alpha"))
+            self.assertTrue(accepted)
+            await orchestrator.wait_for_idle()
+
+            accepted = await orchestrator.submit_utterance(AudioSegment.from_text("bravo"))
+            self.assertTrue(accepted)
+            await orchestrator.wait_for_idle()
+        finally:
+            await orchestrator.stop()
+
+        self.assertEqual(len(language_model.requests), 2)
+        request_messages = language_model.requests[1].messages
+        self.assertEqual(request_messages[0].role, "system")
+        self.assertIn("The conversation language is Japanese.", request_messages[0].content)
+        self.assertEqual(request_messages[1].role, "system")
+        self.assertIn("Earlier conversation summary:", request_messages[1].content)
+        self.assertIn("alpha", request_messages[1].content)
+        self.assertIn("captured", request_messages[1].content)
+        self.assertEqual(
+            [(message.role, message.content) for message in request_messages[2:]],
+            [("user", "bravo")],
         )
 
     async def test_trigger_phrase_adds_screen_capture_parts_to_current_turn(self) -> None:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -191,6 +191,20 @@ class AppSettingsTests(unittest.TestCase):
         self.assertFalse(settings.application_audio.adaptive_vad_enabled)
         self.assertFalse(settings.application_audio.stt_enhancement_enabled)
 
+    def test_from_env_reads_context_compaction_settings(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT": "5",
+                "VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS": "640",
+            },
+            clear=True,
+        ):
+            settings = AppSettings.from_env()
+
+        self.assertEqual(settings.context.recent_message_count, 5)
+        self.assertEqual(settings.context.conversation_summary_max_chars, 640)
+
     def test_from_env_defaults_screen_capture_triggers(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
             settings = AppSettings.from_env()
@@ -199,6 +213,8 @@ class AppSettingsTests(unittest.TestCase):
             settings.screen_capture.trigger_phrases,
             DEFAULT_SCREEN_TRIGGER_PHRASES,
         )
+        self.assertEqual(settings.context.recent_message_count, 8)
+        self.assertEqual(settings.context.conversation_summary_max_chars, 1200)
         self.assertFalse(settings.application_audio.enabled)
         self.assertEqual(
             settings.application_audio.mode,


### PR DESCRIPTION
## Summary
- compact older user/assistant history into a bounded summary
- keep a recent raw-message window for current-turn fidelity
- document and test the new request-shaping behavior

## Testing
- python3 -m unittest discover -s tests -v
- python3 -m compileall src tests

Refs #5
