### PR TITLE
Debounce and merge live microphone turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The repository currently ships with:
 - Implemented: AivisSpeech synthesis over the local HTTP API
 - Implemented: sentence-by-sentence TTS playback with one-sentence-ahead prefetch
 - Implemented: bounded LLM request compaction with an earlier-conversation summary plus a recent raw-message window
+- Implemented: microphone-only reply debounce that merges closely spaced live utterances before one LLM turn
 - Implemented: structured JSON logging and in-memory stage latency metrics
 - Implemented: unit tests for settings, device resolution, utterance accumulation, provider payload/selection logic, queue behavior, and orchestration
 - Not implemented yet: streaming partial STT / LLM / TTS
@@ -90,6 +91,7 @@ Microphone tuning notes:
 - when `VOCALIVE_MIC_DEVICE` is unset and `VOCALIVE_MIC_PREFER_EXTERNAL=true`, VocaLive will switch away from a built-in default mic if it finds a better external input
 - if phrase starts are clipped, increase `VOCALIVE_MIC_PRE_SPEECH_MS`
 - if mid-sentence pauses cause early cuts, increase `VOCALIVE_MIC_SPEECH_HOLD_MS` and `VOCALIVE_MIC_SILENCE_MS`
+- after one live utterance is emitted, VocaLive waits briefly before queueing the LLM turn so closely spaced microphone utterances can merge; tune this with `VOCALIVE_REPLY_DEBOUNCE_MS`
 - in microphone mode, local speech onset interrupts stale assistant playback before the next utterance is fully emitted
 
 Application-audio notes:
@@ -175,6 +177,7 @@ All runtime configuration is environment-driven.
 | `VOCALIVE_CONVERSATION_LANGUAGE` | `ja` | Per-turn language instruction injected before the LLM call; set empty to disable |
 | `VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT` | `8` | Number of recent user/assistant messages kept verbatim in Gemini requests before older dialogue is compacted |
 | `VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS` | `1200` | Character budget for the earlier-conversation summary injected ahead of the recent raw-message window |
+| `VOCALIVE_REPLY_DEBOUNCE_MS` | `1000` | Delay before a microphone user utterance is queued for the LLM so nearby follow-up utterances can merge into one turn |
 | `VOCALIVE_GEMINI_API_KEY` | unset | Gemini API key; `GEMINI_API_KEY` is also accepted |
 | `VOCALIVE_GEMINI_MODEL` | `gemini-2.5-flash` | Gemini model name used for `generateContent` |
 | `VOCALIVE_GEMINI_TIMEOUT_SECONDS` | `30` | Gemini HTTP timeout |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,7 @@ application audio PCM
 shared pipeline
   -> interrupt current turn
   -> bounded ingress queue
+  -> briefly debounce microphone user turns and merge compatible follow-up utterances
   -> STT adapter
   -> append user or application-context message to session
   -> optionally capture the configured window for the current turn when a trigger phrase matches

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,6 +44,7 @@ The current entry point is `src/vocalive/main.py`.
 - the microphone loop keeps reading while the assistant is speaking, so speech onset can stop stale playback immediately
 - in `respond` mode, the application-audio loop also keeps reading while the assistant is speaking, so new app dialogue can stop stale playback immediately
 - older user/assistant turns are compacted into one bounded summary before Gemini requests once the configured recent raw-message window is exceeded
+- microphone user utterances wait for `VOCALIVE_REPLY_DEBOUNCE_MS` before queueing so closely spaced follow-up speech can merge into one LLM turn
 - `VOCALIVE_MIC_DEVICE=external` forces selection of a connected headset-like external mic
 - when `VOCALIVE_MIC_DEVICE` is unset and `VOCALIVE_MIC_PREFER_EXTERNAL=true`, VocaLive prefers a connected external mic over a built-in default input
 - the microphone path uses local RMS thresholding plus silence timing, not a production VAD
@@ -98,6 +99,7 @@ Runtime settings are loaded from `AppSettings.from_env()` in `src/vocalive/confi
 | `VOCALIVE_CONVERSATION_LANGUAGE` | `ja` | Injects a per-turn language instruction before the LLM call; set empty to disable |
 | `VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT` | `8` | Number of recent user/assistant messages kept raw in LLM requests before older conversation is compacted |
 | `VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS` | `1200` | Character budget for the bounded earlier-conversation summary inserted ahead of the recent raw window |
+| `VOCALIVE_REPLY_DEBOUNCE_MS` | `1000` | Delay before a microphone user utterance is queued so nearby follow-up utterances can merge into one turn |
 | `VOCALIVE_GEMINI_API_KEY` | unset | Required for `gemini`; `GEMINI_API_KEY` is also accepted |
 | `VOCALIVE_GEMINI_MODEL` | `gemini-2.5-flash` | Model name passed to `generateContent` |
 | `VOCALIVE_GEMINI_TIMEOUT_SECONDS` | `30` | Gemini HTTP timeout |

--- a/src/vocalive/config/settings.py
+++ b/src/vocalive/config/settings.py
@@ -118,6 +118,11 @@ class OutputSettings:
 
 
 @dataclass
+class ReplySettings:
+    debounce_ms: float = 1000.0
+
+
+@dataclass
 class GeminiSettings:
     api_key: str | None = None
     model_name: str = "gemini-2.5-flash"
@@ -174,6 +179,7 @@ class AppSettings:
     input: InputSettings = field(default_factory=InputSettings)
     application_audio: ApplicationAudioSettings = field(default_factory=ApplicationAudioSettings)
     output: OutputSettings = field(default_factory=OutputSettings)
+    reply: ReplySettings = field(default_factory=ReplySettings)
     gemini: GeminiSettings = field(default_factory=GeminiSettings)
     screen_capture: ScreenCaptureSettings = field(default_factory=ScreenCaptureSettings)
     moonshine: MoonshineSettings = field(default_factory=MoonshineSettings)
@@ -265,6 +271,9 @@ class AppSettings:
                     os.getenv("VOCALIVE_OUTPUT_PROVIDER", OutputProvider.MEMORY.value)
                 ),
                 speaker_command=os.getenv("VOCALIVE_SPEAKER_COMMAND"),
+            ),
+            reply=ReplySettings(
+                debounce_ms=_read_float("VOCALIVE_REPLY_DEBOUNCE_MS", default=1000.0),
             ),
             gemini=GeminiSettings(
                 api_key=os.getenv("VOCALIVE_GEMINI_API_KEY") or os.getenv("GEMINI_API_KEY"),

--- a/src/vocalive/pipeline/orchestrator.py
+++ b/src/vocalive/pipeline/orchestrator.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from vocalive.audio.output import AudioOutput
-from vocalive.config.settings import AppSettings, ApplicationAudioMode
+from vocalive.config.settings import AppSettings, ApplicationAudioMode, InputProvider
 from vocalive.llm.base import LanguageModel
 from vocalive.models import (
     AssistantResponse,
@@ -77,6 +77,10 @@ class ConversationOrchestrator:
         self._interruptions = InterruptionController()
         self._idle_event = asyncio.Event()
         self._work_available = asyncio.Event()
+        self._pending_submission_lock = asyncio.Lock()
+        self._pending_live_segment: AudioSegment | None = None
+        self._pending_live_segment_generation = 0
+        self._pending_live_segment_task: asyncio.Task[None] | None = None
         self._idle_event.set()
         self._worker_task: asyncio.Task[None] | None = None
         self._turn_counter = 0
@@ -89,6 +93,7 @@ class ConversationOrchestrator:
         self._worker_task = asyncio.create_task(self._run(), name="vocalive-orchestrator")
 
     async def stop(self) -> None:
+        await self._discard_pending_live_segment()
         await self._interrupt_active_turn(reason="shutdown", force_stop_audio=True)
         worker_task = self._worker_task
         self._worker_task = None
@@ -103,8 +108,13 @@ class ConversationOrchestrator:
     async def submit_utterance(self, segment: AudioSegment) -> bool:
         if self._should_capture_application_audio_as_context(segment):
             return await self.submit_application_context(segment)
+        if self._should_debounce_live_segment(segment):
+            return await self._submit_debounced_live_segment(segment)
+        return await self._queue_turn_segment(segment, reason="utterance_submitted")
+
+    async def _queue_turn_segment(self, segment: AudioSegment, *, reason: str) -> bool:
         self._idle_event.clear()
-        await self._interrupt_active_turn(reason="utterance_submitted")
+        await self._interrupt_active_turn(reason=reason)
         accepted = await self._queue.put(segment)
         if not accepted:
             self._log_queue_overflow(queue_name="conversation", queue_size=self._queue.qsize())
@@ -112,6 +122,72 @@ class ConversationOrchestrator:
             return False
         self._work_available.set()
         return True
+
+    async def _submit_debounced_live_segment(self, segment: AudioSegment) -> bool:
+        self._idle_event.clear()
+        segment_to_flush: AudioSegment | None = None
+        async with self._pending_submission_lock:
+            pending_segment = self._pending_live_segment
+            if pending_segment is None:
+                self._pending_live_segment = segment
+                self._schedule_pending_live_segment_flush_locked()
+                return True
+            if _segments_can_merge(pending_segment, segment):
+                self._pending_live_segment = _merge_segments(pending_segment, segment)
+                self._schedule_pending_live_segment_flush_locked()
+                return True
+            segment_to_flush = pending_segment
+            self._pending_live_segment = segment
+            self._schedule_pending_live_segment_flush_locked()
+        if segment_to_flush is None:
+            return True
+        return await self._queue_turn_segment(
+            segment_to_flush,
+            reason="debounced_utterance_flushed",
+        )
+
+    def _schedule_pending_live_segment_flush_locked(self) -> None:
+        self._pending_live_segment_generation += 1
+        pending_task = self._pending_live_segment_task
+        if pending_task is not None and not pending_task.done():
+            pending_task.cancel()
+        generation = self._pending_live_segment_generation
+        self._pending_live_segment_task = asyncio.create_task(
+            self._flush_pending_live_segment_after_delay(generation),
+            name=f"vocalive-pending-live-segment-{generation}",
+        )
+
+    async def _flush_pending_live_segment_after_delay(self, generation: int) -> None:
+        try:
+            await asyncio.sleep(max(0.0, self.settings.reply.debounce_ms) / 1000.0)
+        except asyncio.CancelledError:
+            return
+        segment_to_flush: AudioSegment | None = None
+        async with self._pending_submission_lock:
+            if generation != self._pending_live_segment_generation:
+                return
+            segment_to_flush = self._pending_live_segment
+            self._pending_live_segment = None
+            self._pending_live_segment_task = None
+        if segment_to_flush is None:
+            self._set_idle_if_drained()
+            return
+        await self._queue_turn_segment(
+            segment_to_flush,
+            reason="debounced_utterance_ready",
+        )
+
+    async def _discard_pending_live_segment(self) -> None:
+        async with self._pending_submission_lock:
+            self._pending_live_segment = None
+            self._pending_live_segment_generation += 1
+            pending_task = self._pending_live_segment_task
+            self._pending_live_segment_task = None
+        if pending_task is not None and not pending_task.done():
+            pending_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await pending_task
+        self._set_idle_if_drained()
 
     async def submit_application_context(self, segment: AudioSegment) -> bool:
         if segment.source != "application_audio":
@@ -274,11 +350,19 @@ class ConversationOrchestrator:
 
     def _set_idle_if_drained(self) -> None:
         if (
-            self._queue.empty()
+            self._pending_live_segment is None
+            and self._queue.empty()
             and self._application_context_queue.empty()
             and not self._interruptions.has_active_turn
         ):
             self._idle_event.set()
+
+    def _should_debounce_live_segment(self, segment: AudioSegment) -> bool:
+        return (
+            self.settings.input.provider is InputProvider.MICROPHONE
+            and segment.source == "user"
+            and self.settings.reply.debounce_ms > 0.0
+        )
 
     async def _play_response(
         self,
@@ -528,3 +612,34 @@ async def _discard_background_task(task: asyncio.Task[_SynthesizedChunk] | None)
         task.cancel()
     with contextlib.suppress(asyncio.CancelledError, Exception):
         await task
+
+
+def _segments_can_merge(first: AudioSegment, second: AudioSegment) -> bool:
+    return (
+        first.sample_rate_hz == second.sample_rate_hz
+        and first.channels == second.channels
+        and first.sample_width_bytes == second.sample_width_bytes
+        and first.source == second.source
+        and first.source_label == second.source_label
+    )
+
+
+def _merge_segments(first: AudioSegment, second: AudioSegment) -> AudioSegment:
+    if not _segments_can_merge(first, second):
+        raise ValueError("audio segments are not mergeable")
+    return AudioSegment(
+        pcm=first.pcm + second.pcm,
+        sample_rate_hz=first.sample_rate_hz,
+        channels=first.channels,
+        sample_width_bytes=first.sample_width_bytes,
+        transcript_hint=_merge_transcript_hints(first.transcript_hint, second.transcript_hint),
+        source=first.source,
+        source_label=first.source_label,
+    )
+
+
+def _merge_transcript_hints(first: str | None, second: str | None) -> str | None:
+    normalized_parts = [part.strip() for part in (first, second) if part and part.strip()]
+    if not normalized_parts:
+        return None
+    return " ".join(normalized_parts)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -19,8 +19,11 @@ from vocalive.config.settings import (
     ApplicationAudioMode,
     ApplicationAudioSettings,
     ContextSettings,
+    InputProvider,
+    InputSettings,
     QueueSettings,
     QueueOverflowStrategy,
+    ReplySettings,
     ScreenCaptureSettings,
 )
 from vocalive.llm.base import LanguageModel
@@ -314,6 +317,74 @@ class ConversationOrchestratorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             [(message.role, message.content) for message in request_messages[2:]],
             [("user", "bravo")],
+        )
+
+    async def test_microphone_turn_waits_for_reply_debounce_before_llm(self) -> None:
+        language_model = CapturingLanguageModel()
+        orchestrator = ConversationOrchestrator(
+            settings=AppSettings(
+                session_id="test-session",
+                input=InputSettings(provider=InputProvider.MICROPHONE),
+                reply=ReplySettings(debounce_ms=40.0),
+                queue=QueueSettings(
+                    ingress_maxsize=4,
+                    overflow_strategy=QueueOverflowStrategy.DROP_OLDEST,
+                ),
+            ),
+            stt_engine=MockSpeechToTextEngine(),
+            language_model=language_model,
+            tts_engine=MockTextToSpeechEngine(delay_seconds=0.0),
+            audio_output=MemoryAudioOutput(),
+            metrics=InMemoryMetricsRecorder(),
+        )
+        await orchestrator.start()
+        try:
+            accepted = await orchestrator.submit_utterance(AudioSegment.from_text("hello"))
+            self.assertTrue(accepted)
+            await asyncio.sleep(0.01)
+            self.assertEqual(language_model.requests, [])
+            await orchestrator.wait_for_idle()
+        finally:
+            await orchestrator.stop()
+
+        self.assertEqual(len(language_model.requests), 1)
+
+    async def test_microphone_turns_within_reply_debounce_are_merged(self) -> None:
+        language_model = CapturingLanguageModel()
+        orchestrator = ConversationOrchestrator(
+            settings=AppSettings(
+                session_id="test-session",
+                input=InputSettings(provider=InputProvider.MICROPHONE),
+                reply=ReplySettings(debounce_ms=40.0),
+                queue=QueueSettings(
+                    ingress_maxsize=4,
+                    overflow_strategy=QueueOverflowStrategy.DROP_OLDEST,
+                ),
+            ),
+            stt_engine=MockSpeechToTextEngine(),
+            language_model=language_model,
+            tts_engine=MockTextToSpeechEngine(delay_seconds=0.0),
+            audio_output=MemoryAudioOutput(),
+            metrics=InMemoryMetricsRecorder(),
+        )
+        await orchestrator.start()
+        try:
+            accepted = await orchestrator.submit_utterance(AudioSegment.from_text("first"))
+            self.assertTrue(accepted)
+            await asyncio.sleep(0.01)
+            accepted = await orchestrator.submit_utterance(AudioSegment.from_text("second"))
+            self.assertTrue(accepted)
+            await orchestrator.wait_for_idle()
+        finally:
+            await orchestrator.stop()
+
+        self.assertEqual(len(language_model.requests), 1)
+        self.assertEqual(
+            [(message.role, message.content) for message in orchestrator.session.snapshot()],
+            [
+                ("user", "first second"),
+                ("assistant", "captured"),
+            ],
         )
 
     async def test_trigger_phrase_adds_screen_capture_parts_to_current_turn(self) -> None:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -205,6 +205,18 @@ class AppSettingsTests(unittest.TestCase):
         self.assertEqual(settings.context.recent_message_count, 5)
         self.assertEqual(settings.context.conversation_summary_max_chars, 640)
 
+    def test_from_env_reads_reply_debounce_settings(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "VOCALIVE_REPLY_DEBOUNCE_MS": "250",
+            },
+            clear=True,
+        ):
+            settings = AppSettings.from_env()
+
+        self.assertEqual(settings.reply.debounce_ms, 250.0)
+
     def test_from_env_defaults_screen_capture_triggers(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
             settings = AppSettings.from_env()
@@ -215,6 +227,7 @@ class AppSettingsTests(unittest.TestCase):
         )
         self.assertEqual(settings.context.recent_message_count, 8)
         self.assertEqual(settings.context.conversation_summary_max_chars, 1200)
+        self.assertEqual(settings.reply.debounce_ms, 1000.0)
         self.assertFalse(settings.application_audio.enabled)
         self.assertEqual(
             settings.application_audio.mode,


### PR DESCRIPTION
## Summary
- delay microphone turn queueing briefly before LLM dispatch
- merge compatible nearby microphone utterances into one turn
- document and test the live-turn buffering behavior

## Stack
Base branch: `feature/history-summary-window`

## Testing
- python3 -m unittest discover -s tests -v
- python3 -m compileall src tests

Refs #5
