### PR TITLE
Suppress low-value live microphone replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The repository currently ships with:
 - Implemented: sentence-by-sentence TTS playback with one-sentence-ahead prefetch
 - Implemented: bounded LLM request compaction with an earlier-conversation summary plus a recent raw-message window
 - Implemented: microphone-only reply debounce that merges closely spaced live utterances before one LLM turn
+- Implemented: conservative microphone reply suppression for short reactions and cooldown-period chatter while preserving explicit questions/requests
 - Implemented: structured JSON logging and in-memory stage latency metrics
 - Implemented: unit tests for settings, device resolution, utterance accumulation, provider payload/selection logic, queue behavior, and orchestration
 - Not implemented yet: streaming partial STT / LLM / TTS
@@ -92,6 +93,7 @@ Microphone tuning notes:
 - if phrase starts are clipped, increase `VOCALIVE_MIC_PRE_SPEECH_MS`
 - if mid-sentence pauses cause early cuts, increase `VOCALIVE_MIC_SPEECH_HOLD_MS` and `VOCALIVE_MIC_SILENCE_MS`
 - after one live utterance is emitted, VocaLive waits briefly before queueing the LLM turn so closely spaced microphone utterances can merge; tune this with `VOCALIVE_REPLY_DEBOUNCE_MS`
+- microphone reply suppression is enabled by default for live user speech so short reactions such as `やばい` are more likely to stay silent unless they are clear questions/requests; tune this with the `VOCALIVE_REPLY_*` settings
 - in microphone mode, local speech onset interrupts stale assistant playback before the next utterance is fully emitted
 
 Application-audio notes:
@@ -178,6 +180,9 @@ All runtime configuration is environment-driven.
 | `VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT` | `8` | Number of recent user/assistant messages kept verbatim in Gemini requests before older dialogue is compacted |
 | `VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS` | `1200` | Character budget for the earlier-conversation summary injected ahead of the recent raw-message window |
 | `VOCALIVE_REPLY_DEBOUNCE_MS` | `1000` | Delay before a microphone user utterance is queued for the LLM so nearby follow-up utterances can merge into one turn |
+| `VOCALIVE_REPLY_POLICY_ENABLED` | `true` | Enables conservative microphone reply suppression for low-value live chatter |
+| `VOCALIVE_REPLY_MIN_GAP_MS` | `6000` | Minimum time after a completed assistant reply during which short microphone chatter is more likely to be suppressed |
+| `VOCALIVE_REPLY_SHORT_UTTERANCE_MAX_CHARS` | `12` | Maximum normalized length treated as a short microphone reaction for suppression heuristics |
 | `VOCALIVE_GEMINI_API_KEY` | unset | Gemini API key; `GEMINI_API_KEY` is also accepted |
 | `VOCALIVE_GEMINI_MODEL` | `gemini-2.5-flash` | Gemini model name used for `generateContent` |
 | `VOCALIVE_GEMINI_TIMEOUT_SECONDS` | `30` | Gemini HTTP timeout |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,7 @@ shared pipeline
   -> briefly debounce microphone user turns and merge compatible follow-up utterances
   -> STT adapter
   -> append user or application-context message to session
+  -> optionally suppress low-value microphone chatter before screen capture / LLM / TTS
   -> optionally capture the configured window for the current turn when a trigger phrase matches
   -> compact older user/assistant history into one bounded summary while keeping a recent raw-message window
   -> prepend conversation-language system instruction when configured
@@ -174,6 +175,7 @@ Structured logs are emitted for:
 - `turn_interrupted`
 - `turn_cancelled`
 - `turn_failed`
+- `response_suppressed`
 - `screen_capture_ready`
 - `screen_capture_failed`
 - `transcription_ready`

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,6 +45,7 @@ The current entry point is `src/vocalive/main.py`.
 - in `respond` mode, the application-audio loop also keeps reading while the assistant is speaking, so new app dialogue can stop stale playback immediately
 - older user/assistant turns are compacted into one bounded summary before Gemini requests once the configured recent raw-message window is exceeded
 - microphone user utterances wait for `VOCALIVE_REPLY_DEBOUNCE_MS` before queueing so closely spaced follow-up speech can merge into one LLM turn
+- microphone reply suppression is enabled by default for low-value live chatter; explicit questions/requests still bypass the policy
 - `VOCALIVE_MIC_DEVICE=external` forces selection of a connected headset-like external mic
 - when `VOCALIVE_MIC_DEVICE` is unset and `VOCALIVE_MIC_PREFER_EXTERNAL=true`, VocaLive prefers a connected external mic over a built-in default input
 - the microphone path uses local RMS thresholding plus silence timing, not a production VAD
@@ -100,6 +101,9 @@ Runtime settings are loaded from `AppSettings.from_env()` in `src/vocalive/confi
 | `VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT` | `8` | Number of recent user/assistant messages kept raw in LLM requests before older conversation is compacted |
 | `VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS` | `1200` | Character budget for the bounded earlier-conversation summary inserted ahead of the recent raw window |
 | `VOCALIVE_REPLY_DEBOUNCE_MS` | `1000` | Delay before a microphone user utterance is queued so nearby follow-up utterances can merge into one turn |
+| `VOCALIVE_REPLY_POLICY_ENABLED` | `true` | Enables conservative reply suppression for low-value live microphone chatter |
+| `VOCALIVE_REPLY_MIN_GAP_MS` | `6000` | Minimum time after a completed assistant reply during which short microphone chatter is more likely to be suppressed |
+| `VOCALIVE_REPLY_SHORT_UTTERANCE_MAX_CHARS` | `12` | Maximum normalized length treated as a short microphone reaction by the suppression heuristics |
 | `VOCALIVE_GEMINI_API_KEY` | unset | Required for `gemini`; `GEMINI_API_KEY` is also accepted |
 | `VOCALIVE_GEMINI_MODEL` | `gemini-2.5-flash` | Model name passed to `generateContent` |
 | `VOCALIVE_GEMINI_TIMEOUT_SECONDS` | `30` | Gemini HTTP timeout |

--- a/src/vocalive/config/settings.py
+++ b/src/vocalive/config/settings.py
@@ -120,6 +120,9 @@ class OutputSettings:
 @dataclass
 class ReplySettings:
     debounce_ms: float = 1000.0
+    policy_enabled: bool = True
+    min_gap_ms: float = 6000.0
+    short_utterance_max_chars: int = 12
 
 
 @dataclass
@@ -274,6 +277,12 @@ class AppSettings:
             ),
             reply=ReplySettings(
                 debounce_ms=_read_float("VOCALIVE_REPLY_DEBOUNCE_MS", default=1000.0),
+                policy_enabled=_read_bool("VOCALIVE_REPLY_POLICY_ENABLED", default=True),
+                min_gap_ms=_read_float("VOCALIVE_REPLY_MIN_GAP_MS", default=6000.0),
+                short_utterance_max_chars=_read_int(
+                    "VOCALIVE_REPLY_SHORT_UTTERANCE_MAX_CHARS",
+                    default=12,
+                ),
             ),
             gemini=GeminiSettings(
                 api_key=os.getenv("VOCALIVE_GEMINI_API_KEY") or os.getenv("GEMINI_API_KEY"),

--- a/src/vocalive/pipeline/orchestrator.py
+++ b/src/vocalive/pipeline/orchestrator.py
@@ -27,6 +27,7 @@ from vocalive.pipeline.interruption import (
     TurnCancelledError,
 )
 from vocalive.pipeline.queues import BoundedAsyncQueue
+from vocalive.pipeline.reply_policy import ReplyDecision, decide_reply
 from vocalive.pipeline.session import ConversationSession
 from vocalive.screen.base import ScreenCaptureEngine
 from vocalive.stt.base import SpeechToTextEngine
@@ -86,6 +87,7 @@ class ConversationOrchestrator:
         self._turn_counter = 0
         self._active_context: TurnContext | None = None
         self._active_stage: str | None = None
+        self._last_assistant_response_ms: float | None = None
 
     async def start(self) -> None:
         if self._worker_task is not None:
@@ -282,6 +284,27 @@ class ConversationOrchestrator:
             current_user_parts = tuple()
         else:
             self.session.append_user_message(session_message_text)
+            reply_decision = self._decide_user_reply(
+                transcription_text=transcription.text,
+                segment=segment,
+            )
+            if not reply_decision.should_reply:
+                log_event(
+                    self.logger,
+                    "response_suppressed",
+                    session_id=context.session_id,
+                    turn_id=context.turn_id,
+                    reason=reply_decision.reason,
+                    text=transcription.text,
+                    audio_source=segment.source,
+                )
+                self._active_stage = None
+                self.metrics.record_duration(
+                    stage="turn_total",
+                    duration_ms=monotonic_ms() - turn_started_ms,
+                    context=context,
+                )
+                return
             current_user_parts = await self._maybe_capture_current_user_parts(
                 user_text=transcription.text,
                 context=context,
@@ -311,6 +334,7 @@ class ConversationOrchestrator:
         await self._play_response(response=response, context=context, cancellation=cancellation)
 
         self.session.append_assistant_message(response.text)
+        self._last_assistant_response_ms = monotonic_ms()
         self._active_stage = None
         self.metrics.record_duration(
             stage="turn_total",
@@ -457,6 +481,26 @@ class ConversationOrchestrator:
         if language_instruction is not None:
             messages.insert(0, ConversationMessage(role="system", content=language_instruction))
         return tuple(messages)
+
+    def _decide_user_reply(
+        self,
+        transcription_text: str,
+        segment: AudioSegment,
+    ) -> ReplyDecision:
+        if (
+            self.settings.input.provider is not InputProvider.MICROPHONE
+            or segment.source != "user"
+        ):
+            return ReplyDecision(
+                should_reply=True,
+                reason="policy_not_applicable",
+            )
+        return decide_reply(
+            transcription_text,
+            settings=self.settings.reply,
+            last_assistant_response_ms=self._last_assistant_response_ms,
+            now_ms=monotonic_ms(),
+        )
 
     async def _maybe_capture_current_user_parts(
         self,

--- a/src/vocalive/pipeline/reply_policy.py
+++ b/src/vocalive/pipeline/reply_policy.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vocalive.config.settings import ReplySettings
+
+
+_EXPLICIT_REQUEST_MARKERS = (
+    "?",
+    "？",
+    "教えて",
+    "おしえて",
+    "どうすれば",
+    "どうやって",
+    "なんで",
+    "なぜ",
+    "なに",
+    "何",
+    "どこ",
+    "いつ",
+    "help",
+    "please",
+    "can you",
+    "could you",
+    "what",
+    "why",
+    "how",
+)
+_GREETING_MARKERS = {
+    "こんにちは",
+    "こんばんは",
+    "おはよう",
+    "hello",
+    "hi",
+    "hey",
+}
+_SHORT_REACTION_MARKERS = {
+    "あ",
+    "あっ",
+    "あー",
+    "え",
+    "えっ",
+    "うわ",
+    "うわっ",
+    "うわー",
+    "おっ",
+    "おー",
+    "よし",
+    "やばい",
+    "やば",
+    "まじ",
+    "なるほど",
+    "くそ",
+    "くっ",
+    "痛い",
+    "惜しい",
+}
+
+
+@dataclass(frozen=True)
+class ReplyDecision:
+    should_reply: bool
+    reason: str
+
+
+def decide_reply(
+    text: str,
+    *,
+    settings: ReplySettings,
+    last_assistant_response_ms: float | None,
+    now_ms: float,
+) -> ReplyDecision:
+    if not settings.policy_enabled:
+        return ReplyDecision(should_reply=True, reason="policy_disabled")
+
+    normalized_text = "".join(text.lower().split())
+    if not normalized_text:
+        return ReplyDecision(should_reply=False, reason="empty_text")
+
+    if _looks_like_explicit_request(normalized_text):
+        return ReplyDecision(should_reply=True, reason="explicit_request")
+
+    if last_assistant_response_ms is None and normalized_text in _GREETING_MARKERS:
+        return ReplyDecision(should_reply=True, reason="greeting")
+
+    if _looks_like_short_reaction(
+        normalized_text,
+        short_utterance_max_chars=settings.short_utterance_max_chars,
+    ):
+        return ReplyDecision(should_reply=False, reason="short_reaction")
+
+    if (
+        last_assistant_response_ms is not None
+        and (now_ms - last_assistant_response_ms) < settings.min_gap_ms
+        and len(normalized_text) <= max(24, settings.short_utterance_max_chars * 2)
+    ):
+        return ReplyDecision(should_reply=False, reason="cooldown")
+
+    return ReplyDecision(should_reply=True, reason="default")
+
+
+def _looks_like_explicit_request(normalized_text: str) -> bool:
+    return any(marker in normalized_text for marker in _EXPLICIT_REQUEST_MARKERS)
+
+
+def _looks_like_short_reaction(
+    normalized_text: str,
+    *,
+    short_utterance_max_chars: int,
+) -> bool:
+    if len(normalized_text) > max(0, short_utterance_max_chars):
+        return False
+    return (
+        normalized_text in _SHORT_REACTION_MARKERS
+        or normalized_text.endswith("!")
+        or normalized_text.endswith("！")
+    )

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -387,6 +387,95 @@ class ConversationOrchestratorTests(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_short_microphone_reaction_is_suppressed_after_recent_reply(self) -> None:
+        language_model = CapturingLanguageModel()
+        orchestrator = ConversationOrchestrator(
+            settings=AppSettings(
+                session_id="test-session",
+                input=InputSettings(provider=InputProvider.MICROPHONE),
+                reply=ReplySettings(
+                    debounce_ms=0.0,
+                    min_gap_ms=5000.0,
+                    short_utterance_max_chars=12,
+                ),
+                queue=QueueSettings(
+                    ingress_maxsize=4,
+                    overflow_strategy=QueueOverflowStrategy.DROP_OLDEST,
+                ),
+            ),
+            stt_engine=MockSpeechToTextEngine(),
+            language_model=language_model,
+            tts_engine=MockTextToSpeechEngine(delay_seconds=0.0),
+            audio_output=MemoryAudioOutput(),
+            metrics=InMemoryMetricsRecorder(),
+        )
+        await orchestrator.start()
+        try:
+            accepted = await orchestrator.submit_utterance(AudioSegment.from_text("こんにちは"))
+            self.assertTrue(accepted)
+            await orchestrator.wait_for_idle()
+
+            accepted = await orchestrator.submit_utterance(AudioSegment.from_text("やばい"))
+            self.assertTrue(accepted)
+            await orchestrator.wait_for_idle()
+        finally:
+            await orchestrator.stop()
+
+        self.assertEqual(len(language_model.requests), 1)
+        self.assertEqual(
+            [(message.role, message.content) for message in orchestrator.session.snapshot()],
+            [
+                ("user", "こんにちは"),
+                ("assistant", "captured"),
+                ("user", "やばい"),
+            ],
+        )
+
+    async def test_explicit_microphone_question_bypasses_reply_suppression(self) -> None:
+        language_model = CapturingLanguageModel()
+        orchestrator = ConversationOrchestrator(
+            settings=AppSettings(
+                session_id="test-session",
+                input=InputSettings(provider=InputProvider.MICROPHONE),
+                reply=ReplySettings(
+                    debounce_ms=0.0,
+                    min_gap_ms=5000.0,
+                    short_utterance_max_chars=12,
+                ),
+                queue=QueueSettings(
+                    ingress_maxsize=4,
+                    overflow_strategy=QueueOverflowStrategy.DROP_OLDEST,
+                ),
+            ),
+            stt_engine=MockSpeechToTextEngine(),
+            language_model=language_model,
+            tts_engine=MockTextToSpeechEngine(delay_seconds=0.0),
+            audio_output=MemoryAudioOutput(),
+            metrics=InMemoryMetricsRecorder(),
+        )
+        await orchestrator.start()
+        try:
+            accepted = await orchestrator.submit_utterance(AudioSegment.from_text("こんにちは"))
+            self.assertTrue(accepted)
+            await orchestrator.wait_for_idle()
+
+            accepted = await orchestrator.submit_utterance(AudioSegment.from_text("なんで？"))
+            self.assertTrue(accepted)
+            await orchestrator.wait_for_idle()
+        finally:
+            await orchestrator.stop()
+
+        self.assertEqual(len(language_model.requests), 2)
+        self.assertEqual(
+            [(message.role, message.content) for message in orchestrator.session.snapshot()],
+            [
+                ("user", "こんにちは"),
+                ("assistant", "captured"),
+                ("user", "なんで？"),
+                ("assistant", "captured"),
+            ],
+        )
+
     async def test_trigger_phrase_adds_screen_capture_parts_to_current_turn(self) -> None:
         language_model = MultimodalCapturingLanguageModel()
         screen_capture_engine = StubScreenCaptureEngine()

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -210,12 +210,18 @@ class AppSettingsTests(unittest.TestCase):
             os.environ,
             {
                 "VOCALIVE_REPLY_DEBOUNCE_MS": "250",
+                "VOCALIVE_REPLY_POLICY_ENABLED": "false",
+                "VOCALIVE_REPLY_MIN_GAP_MS": "4200",
+                "VOCALIVE_REPLY_SHORT_UTTERANCE_MAX_CHARS": "9",
             },
             clear=True,
         ):
             settings = AppSettings.from_env()
 
         self.assertEqual(settings.reply.debounce_ms, 250.0)
+        self.assertFalse(settings.reply.policy_enabled)
+        self.assertEqual(settings.reply.min_gap_ms, 4200.0)
+        self.assertEqual(settings.reply.short_utterance_max_chars, 9)
 
     def test_from_env_defaults_screen_capture_triggers(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
@@ -228,6 +234,9 @@ class AppSettingsTests(unittest.TestCase):
         self.assertEqual(settings.context.recent_message_count, 8)
         self.assertEqual(settings.context.conversation_summary_max_chars, 1200)
         self.assertEqual(settings.reply.debounce_ms, 1000.0)
+        self.assertTrue(settings.reply.policy_enabled)
+        self.assertEqual(settings.reply.min_gap_ms, 6000.0)
+        self.assertEqual(settings.reply.short_utterance_max_chars, 12)
         self.assertFalse(settings.application_audio.enabled)
         self.assertEqual(
             settings.application_audio.mode,


### PR DESCRIPTION
## Summary
- add a conservative live reply policy for microphone turns
- suppress short low-value reactions and cooldown-period chatter
- preserve explicit questions and requests

## Stack
Base branch: `feature/reply-debounce-merge`

## Testing
- python3 -m unittest discover -s tests -v
- python3 -m compileall src tests

Refs #5
