### PR TITLE
Compact older application audio context

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The repository currently ships with:
 - Implemented: bounded LLM request compaction with an earlier-conversation summary plus a recent raw-message window
 - Implemented: microphone-only reply debounce that merges closely spaced live utterances before one LLM turn
 - Implemented: conservative microphone reply suppression for short reactions and cooldown-period chatter while preserving explicit questions/requests
+- Implemented: separate application-audio summary compaction so older app context does not stay fully verbatim in every LLM request
 - Implemented: structured JSON logging and in-memory stage latency metrics
 - Implemented: unit tests for settings, device resolution, utterance accumulation, provider payload/selection logic, queue behavior, and orchestration
 - Not implemented yet: streaming partial STT / LLM / TTS
@@ -100,6 +101,7 @@ Application-audio notes:
 
 - application audio can be enabled alongside either `stdin` or `microphone` input
 - `VOCALIVE_APP_AUDIO_MODE=context_only` is the default; app audio is transcribed and appended to session history as labeled application context, but it does not immediately trigger LLM/TTS or interrupt active playback
+- older application-audio entries are compacted into a separate bounded summary while the newest configured app-context messages stay verbatim in the LLM request window
 - set `VOCALIVE_APP_AUDIO_MODE=respond` when you want application-audio utterances to behave like live turns and trigger immediate assistant replies
 - the configured target is matched against the running macOS application name first and bundle identifier second
 - application audio uses adaptive energy-based VAD by default so steady BGM is more likely to stay in the background; set `VOCALIVE_APP_AUDIO_ADAPTIVE_VAD=false` to fall back to fixed thresholding
@@ -179,6 +181,9 @@ All runtime configuration is environment-driven.
 | `VOCALIVE_CONVERSATION_LANGUAGE` | `ja` | Per-turn language instruction injected before the LLM call; set empty to disable |
 | `VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT` | `8` | Number of recent user/assistant messages kept verbatim in Gemini requests before older dialogue is compacted |
 | `VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS` | `1200` | Character budget for the earlier-conversation summary injected ahead of the recent raw-message window |
+| `VOCALIVE_CONTEXT_APPLICATION_RECENT_MESSAGE_COUNT` | `4` | Number of recent application-audio messages kept verbatim in Gemini requests before older app context is compacted |
+| `VOCALIVE_CONTEXT_APPLICATION_SUMMARY_MAX_CHARS` | `900` | Character budget for the earlier application-audio summary injected ahead of the recent raw app-context window |
+| `VOCALIVE_CONTEXT_APPLICATION_MIN_MESSAGE_CHARS` | `8` | Minimum normalized application-audio message length kept in the older app-context summary |
 | `VOCALIVE_REPLY_DEBOUNCE_MS` | `1000` | Delay before a microphone user utterance is queued for the LLM so nearby follow-up utterances can merge into one turn |
 | `VOCALIVE_REPLY_POLICY_ENABLED` | `true` | Enables conservative microphone reply suppression for low-value live chatter |
 | `VOCALIVE_REPLY_MIN_GAP_MS` | `6000` | Minimum time after a completed assistant reply during which short microphone chatter is more likely to be suppressed |
@@ -213,6 +218,7 @@ Current provider support:
 - `VOCALIVE_MOONSHINE_MODEL=base` resolves a language-specific Moonshine model from `VOCALIVE_CONVERSATION_LANGUAGE`, so the default Japanese configuration resolves to `base-ja`
 - `gemini` uses the Gemini `generateContent` API over HTTPS; the default config sets `thinkingBudget=0` to reduce latency
 - optional application-audio capture resolves one running macOS app, segments its audio into utterances, and by default submits those transcripts as labeled application context without immediate assistant replies
+- older application-audio context is compacted into one bounded system summary while the newest configured app-audio messages remain verbatim in requests
 - optional screen capture resolves a named on-screen window on macOS and attaches one PNG of that window to the current Gemini turn when a trigger phrase matches
 - older user/assistant dialogue is compacted into one bounded system summary before Gemini requests so long sessions do not resend the entire raw conversation every turn
 - `aivis` uses the local AivisSpeech engine API and resolves a style id from `/speakers` when needed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,7 @@ shared pipeline
   -> optionally suppress low-value microphone chatter before screen capture / LLM / TTS
   -> optionally capture the configured window for the current turn when a trigger phrase matches
   -> compact older user/assistant history into one bounded summary while keeping a recent raw-message window
+  -> compact older application-audio context into a separate bounded summary while keeping a recent raw app-context window
   -> prepend conversation-language system instruction when configured
   -> LLM adapter
   -> split assistant text into sentence-sized chunks
@@ -122,7 +123,7 @@ This prevents unbounded backlog growth and avoids finishing obsolete replies aft
 - user messages are appended after STT completes
 - application-audio transcripts are appended after STT completes as labeled `application` context messages, not user messages
 - in the default `context_only` mode, those application messages do not immediately trigger LLM/TTS; they are consumed on the next user-driven turn
-- the LLM receives a compacted session view: recent user/assistant raw messages plus one bounded earlier-conversation summary and an optional conversation-language system instruction
+- the LLM receives a compacted session view: recent user/assistant raw messages, one bounded earlier-conversation summary, recent application-audio raw messages, one bounded earlier application-audio summary, and an optional conversation-language system instruction
 - screen captures are request-scoped extras for the current user turn only and are not persisted in session history
 - assistant messages are appended only after the full reply has been synthesized and played
 - interrupted assistant replies are therefore not committed to session history

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,6 +46,7 @@ The current entry point is `src/vocalive/main.py`.
 - older user/assistant turns are compacted into one bounded summary before Gemini requests once the configured recent raw-message window is exceeded
 - microphone user utterances wait for `VOCALIVE_REPLY_DEBOUNCE_MS` before queueing so closely spaced follow-up speech can merge into one LLM turn
 - microphone reply suppression is enabled by default for low-value live chatter; explicit questions/requests still bypass the policy
+- older application-audio context is compacted into its own bounded summary while the newest configured app-audio messages stay verbatim in Gemini requests
 - `VOCALIVE_MIC_DEVICE=external` forces selection of a connected headset-like external mic
 - when `VOCALIVE_MIC_DEVICE` is unset and `VOCALIVE_MIC_PREFER_EXTERNAL=true`, VocaLive prefers a connected external mic over a built-in default input
 - the microphone path uses local RMS thresholding plus silence timing, not a production VAD
@@ -100,6 +101,9 @@ Runtime settings are loaded from `AppSettings.from_env()` in `src/vocalive/confi
 | `VOCALIVE_CONVERSATION_LANGUAGE` | `ja` | Injects a per-turn language instruction before the LLM call; set empty to disable |
 | `VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT` | `8` | Number of recent user/assistant messages kept raw in LLM requests before older conversation is compacted |
 | `VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS` | `1200` | Character budget for the bounded earlier-conversation summary inserted ahead of the recent raw window |
+| `VOCALIVE_CONTEXT_APPLICATION_RECENT_MESSAGE_COUNT` | `4` | Number of recent application-audio messages kept raw in LLM requests before older app context is compacted |
+| `VOCALIVE_CONTEXT_APPLICATION_SUMMARY_MAX_CHARS` | `900` | Character budget for the bounded earlier application-audio summary inserted ahead of the recent raw app-context window |
+| `VOCALIVE_CONTEXT_APPLICATION_MIN_MESSAGE_CHARS` | `8` | Minimum normalized application-audio message length kept in the older app-context summary |
 | `VOCALIVE_REPLY_DEBOUNCE_MS` | `1000` | Delay before a microphone user utterance is queued so nearby follow-up utterances can merge into one turn |
 | `VOCALIVE_REPLY_POLICY_ENABLED` | `true` | Enables conservative reply suppression for low-value live microphone chatter |
 | `VOCALIVE_REPLY_MIN_GAP_MS` | `6000` | Minimum time after a completed assistant reply during which short microphone chatter is more likely to be suppressed |

--- a/src/vocalive/config/settings.py
+++ b/src/vocalive/config/settings.py
@@ -153,6 +153,9 @@ class ConversationSettings:
 class ContextSettings:
     recent_message_count: int = 8
     conversation_summary_max_chars: int = 1200
+    application_recent_message_count: int = 4
+    application_summary_max_chars: int = 900
+    application_summary_min_message_chars: int = 8
 
 
 @dataclass
@@ -221,6 +224,18 @@ class AppSettings:
                 conversation_summary_max_chars=_read_int(
                     "VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS",
                     default=1200,
+                ),
+                application_recent_message_count=_read_int(
+                    "VOCALIVE_CONTEXT_APPLICATION_RECENT_MESSAGE_COUNT",
+                    default=4,
+                ),
+                application_summary_max_chars=_read_int(
+                    "VOCALIVE_CONTEXT_APPLICATION_SUMMARY_MAX_CHARS",
+                    default=900,
+                ),
+                application_summary_min_message_chars=_read_int(
+                    "VOCALIVE_CONTEXT_APPLICATION_MIN_MESSAGE_CHARS",
+                    default=8,
                 ),
             ),
             input=InputSettings(

--- a/src/vocalive/pipeline/context.py
+++ b/src/vocalive/pipeline/context.py
@@ -8,6 +8,7 @@ _SUMMARY_ROLE_LABELS = {
     "assistant": "Assistant",
 }
 _OMITTED_LINE = "- Earlier summarized turns omitted for brevity."
+_APPLICATION_PREFIX = "Application audio ("
 
 
 def build_compacted_messages(
@@ -15,45 +16,65 @@ def build_compacted_messages(
     *,
     recent_message_count: int,
     conversation_summary_max_chars: int,
+    application_recent_message_count: int = 0,
+    application_summary_max_chars: int = 0,
+    application_summary_min_message_chars: int = 0,
 ) -> tuple[ConversationMessage, ...]:
-    recent_indexes = _select_recent_conversation_indexes(
+    recent_conversation_indexes = _select_recent_indexes(
         messages,
+        roles={"user", "assistant"},
         recent_message_count=max(0, recent_message_count),
     )
+    recent_application_indexes = _select_recent_indexes(
+        messages,
+        roles={"application"},
+        recent_message_count=max(0, application_recent_message_count),
+    )
     older_conversation_messages: list[ConversationMessage] = []
+    older_application_messages: list[ConversationMessage] = []
     compacted_messages: list[ConversationMessage] = []
 
     for index, message in enumerate(messages):
-        if (
-            message.role in {"user", "assistant"}
-            and index not in recent_indexes
-        ):
+        if message.role in {"user", "assistant"} and index not in recent_conversation_indexes:
             older_conversation_messages.append(message)
+            continue
+        if message.role == "application" and index not in recent_application_indexes:
+            older_application_messages.append(message)
             continue
         compacted_messages.append(message)
 
-    summary = _build_conversation_summary(
+    summary_messages: list[ConversationMessage] = []
+    conversation_summary = _build_conversation_summary(
         older_conversation_messages,
         max_chars=conversation_summary_max_chars,
     )
-    if summary is None:
-        return tuple(compacted_messages)
-    return (
-        ConversationMessage(role="system", content=summary),
-        *compacted_messages,
+    if conversation_summary is not None:
+        summary_messages.append(
+            ConversationMessage(role="system", content=conversation_summary)
+        )
+    application_summary = _build_application_summary(
+        older_application_messages,
+        max_chars=application_summary_max_chars,
+        min_message_chars=application_summary_min_message_chars,
     )
+    if application_summary is not None:
+        summary_messages.append(
+            ConversationMessage(role="system", content=application_summary)
+        )
+    return tuple(summary_messages + compacted_messages)
 
 
-def _select_recent_conversation_indexes(
+def _select_recent_indexes(
     messages: tuple[ConversationMessage, ...],
     *,
+    roles: set[str],
     recent_message_count: int,
 ) -> set[int]:
     if recent_message_count <= 0:
         return set()
     recent_indexes: list[int] = []
     for index in range(len(messages) - 1, -1, -1):
-        if messages[index].role not in {"user", "assistant"}:
+        if messages[index].role not in roles:
             continue
         recent_indexes.append(index)
         if len(recent_indexes) >= recent_message_count:
@@ -74,6 +95,52 @@ def _build_conversation_summary(
         _format_summary_line(message, max_chars=line_char_limit)
         for message in messages
     ]
+    compacted_lines = _fit_summary_lines(lines, header=header, max_chars=max_chars)
+    if not compacted_lines:
+        return None
+    return header + "\n" + "\n".join(compacted_lines)
+
+
+def _build_application_summary(
+    messages: list[ConversationMessage],
+    *,
+    max_chars: int,
+    min_message_chars: int,
+) -> str | None:
+    if max_chars <= 0 or not messages:
+        return None
+    header = "Earlier application audio summary:"
+    line_char_limit = max(32, min(140, max_chars // 4))
+    lines: list[str] = []
+    previous_key: tuple[str, str] | None = None
+    previous_count = 0
+
+    def flush_previous() -> None:
+        nonlocal previous_key, previous_count
+        if previous_key is None:
+            return
+        source_label, content = previous_key
+        suffix = f" (x{previous_count})" if previous_count > 1 else ""
+        lines.append(
+            f"- {source_label}: {_trim_line(content, max_chars=line_char_limit)}{suffix}"
+        )
+        previous_key = None
+        previous_count = 0
+
+    for message in messages:
+        source_label, content = _parse_application_audio_message(message.content)
+        normalized_content = " ".join(content.split())
+        if len(normalized_content) < max(0, min_message_chars):
+            continue
+        key = (source_label, normalized_content)
+        if key == previous_key:
+            previous_count += 1
+            continue
+        flush_previous()
+        previous_key = key
+        previous_count = 1
+    flush_previous()
+
     compacted_lines = _fit_summary_lines(lines, header=header, max_chars=max_chars)
     if not compacted_lines:
         return None
@@ -122,3 +189,10 @@ def _trim_line(value: str, *, max_chars: int) -> str:
 
 def _render_summary(header: str, lines: list[str]) -> str:
     return header + "\n" + "\n".join(lines)
+
+
+def _parse_application_audio_message(value: str) -> tuple[str, str]:
+    if value.startswith(_APPLICATION_PREFIX) and "):" in value:
+        raw_label, content = value[len(_APPLICATION_PREFIX) :].split("):", maxsplit=1)
+        return (raw_label.strip() or "application", content.strip())
+    return ("application", value.strip())

--- a/src/vocalive/pipeline/orchestrator.py
+++ b/src/vocalive/pipeline/orchestrator.py
@@ -475,6 +475,15 @@ class ConversationOrchestrator:
                 conversation_summary_max_chars=(
                     self.settings.context.conversation_summary_max_chars
                 ),
+                application_recent_message_count=(
+                    self.settings.context.application_recent_message_count
+                ),
+                application_summary_max_chars=(
+                    self.settings.context.application_summary_max_chars
+                ),
+                application_summary_min_message_chars=(
+                    self.settings.context.application_summary_min_message_chars
+                ),
             )
         )
         language_instruction = _build_conversation_language_instruction(conversation_language)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -683,6 +683,70 @@ class ConversationOrchestratorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(screen_capture_engine.calls, [])
         self.assertEqual(language_model.requests, [])
 
+    async def test_older_application_audio_is_compacted_into_separate_summary(self) -> None:
+        language_model = CapturingLanguageModel()
+        orchestrator = ConversationOrchestrator(
+            settings=AppSettings(
+                session_id="test-session",
+                queue=QueueSettings(
+                    ingress_maxsize=4,
+                    overflow_strategy=QueueOverflowStrategy.DROP_OLDEST,
+                ),
+                context=ContextSettings(
+                    recent_message_count=8,
+                    conversation_summary_max_chars=220,
+                    application_recent_message_count=1,
+                    application_summary_max_chars=220,
+                    application_summary_min_message_chars=4,
+                ),
+            ),
+            stt_engine=MockSpeechToTextEngine(),
+            language_model=language_model,
+            tts_engine=MockTextToSpeechEngine(delay_seconds=0.0),
+            audio_output=MemoryAudioOutput(),
+            metrics=InMemoryMetricsRecorder(),
+        )
+        await orchestrator.start()
+        try:
+            accepted = await orchestrator.submit_utterance(
+                AudioSegment.from_text(
+                    "boss incoming",
+                    source="application_audio",
+                    source_label="Steam",
+                )
+            )
+            self.assertTrue(accepted)
+            await orchestrator.wait_for_idle()
+
+            accepted = await orchestrator.submit_utterance(
+                AudioSegment.from_text(
+                    "door opened",
+                    source="application_audio",
+                    source_label="Steam",
+                )
+            )
+            self.assertTrue(accepted)
+            await orchestrator.wait_for_idle()
+
+            accepted = await orchestrator.submit_utterance(AudioSegment.from_text("どうする？"))
+            self.assertTrue(accepted)
+            await orchestrator.wait_for_idle()
+        finally:
+            await orchestrator.stop()
+
+        self.assertEqual(len(language_model.requests), 1)
+        request_messages = language_model.requests[0].messages
+        self.assertEqual(request_messages[1].role, "system")
+        self.assertIn("Earlier application audio summary:", request_messages[1].content)
+        self.assertIn("boss incoming", request_messages[1].content)
+        self.assertEqual(
+            [(message.role, message.content) for message in request_messages[2:]],
+            [
+                ("application", "Application audio (Steam): door opened"),
+                ("user", "どうする？"),
+            ],
+        )
+
     async def test_context_only_application_audio_does_not_interrupt_active_playback(self) -> None:
         output = MemoryAudioOutput(chunk_delay_seconds=0.02, chunk_size_bytes=1)
         self.orchestrator.audio_output = output

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -197,6 +197,9 @@ class AppSettingsTests(unittest.TestCase):
             {
                 "VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT": "5",
                 "VOCALIVE_CONTEXT_CONVERSATION_SUMMARY_MAX_CHARS": "640",
+                "VOCALIVE_CONTEXT_APPLICATION_RECENT_MESSAGE_COUNT": "2",
+                "VOCALIVE_CONTEXT_APPLICATION_SUMMARY_MAX_CHARS": "420",
+                "VOCALIVE_CONTEXT_APPLICATION_MIN_MESSAGE_CHARS": "5",
             },
             clear=True,
         ):
@@ -204,6 +207,9 @@ class AppSettingsTests(unittest.TestCase):
 
         self.assertEqual(settings.context.recent_message_count, 5)
         self.assertEqual(settings.context.conversation_summary_max_chars, 640)
+        self.assertEqual(settings.context.application_recent_message_count, 2)
+        self.assertEqual(settings.context.application_summary_max_chars, 420)
+        self.assertEqual(settings.context.application_summary_min_message_chars, 5)
 
     def test_from_env_reads_reply_debounce_settings(self) -> None:
         with patch.dict(
@@ -233,6 +239,9 @@ class AppSettingsTests(unittest.TestCase):
         )
         self.assertEqual(settings.context.recent_message_count, 8)
         self.assertEqual(settings.context.conversation_summary_max_chars, 1200)
+        self.assertEqual(settings.context.application_recent_message_count, 4)
+        self.assertEqual(settings.context.application_summary_max_chars, 900)
+        self.assertEqual(settings.context.application_summary_min_message_chars, 8)
         self.assertEqual(settings.reply.debounce_ms, 1000.0)
         self.assertTrue(settings.reply.policy_enabled)
         self.assertEqual(settings.reply.min_gap_ms, 6000.0)


### PR DESCRIPTION
## Summary
- compact older application-audio context into its own bounded summary
- keep only the newest configured app-audio messages verbatim in requests
- document and test the separate app-context compaction behavior

## Stack
Base branch: `feature/reply-suppress-policy`

## Testing
- python3 -m unittest discover -s tests -v
- python3 -m compileall src tests

Closes #5
