### PR TITLE
Add Windows live capture support and harden audio I/O

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -13,7 +13,7 @@ Current runtime modes:
 - `stdin` shell for local development and provider wiring checks
 - `microphone` capture via `sounddevice` with local utterance detection
 - optional local browser overlay for transparent on-screen character captions
-- optional macOS application-audio capture layered onto `stdin` or `microphone`
+- optional application-audio capture layered onto `stdin` or `microphone` on macOS or Windows
 
 Current default assembly:
 
@@ -39,9 +39,11 @@ Current optional presentation path:
 Current hard constraints in the shipped app assembly:
 
 - live microphone or application-audio input requires a real STT adapter, currently `moonshine`
-- application-audio capture currently requires macOS, `VOCALIVE_APP_AUDIO_TARGET`, and Screen Recording permission
+- application-audio capture currently requires `VOCALIVE_APP_AUDIO_TARGET`; macOS also requires Screen Recording permission, and Windows uses WASAPI process loopback for the selected process tree while the target process stays alive
+- Windows application-audio capture depends on `csc.exe` plus a Windows build with process-loopback support
+- screen capture currently supports macOS and Windows; macOS also requires Screen Recording permission
 - `VOCALIVE_OUTPUT_PROVIDER=speaker` currently requires `VOCALIVE_TTS_PROVIDER=aivis`
-- speaker playback uses `afplay` by default on macOS unless `VOCALIVE_SPEAKER_COMMAND` is set
+- speaker playback uses `afplay` by default on macOS and PowerShell `SoundPlayer` on Windows unless `VOCALIVE_SPEAKER_COMMAND` is set
 - the overlay is local browser UI only; it is driven by playback-chunk events rather than model token streaming
 
 ## Current behavior that changes must preserve

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The repository currently ships with:
 
 - a stdin shell for local development
 - optional live microphone capture via `sounddevice`
-- optional macOS application-audio capture for one named running app
+- optional application-audio capture for one named running app on macOS or Windows
 - mock providers for end-to-end local testing
 - Moonshine STT, Gemini LLM, and AivisSpeech TTS adapters
 - in-memory output for tests and speaker playback through an external command
@@ -18,14 +18,15 @@ The repository currently ships with:
 - Implemented: stale-turn interruption on new utterances
 - Implemented: microphone speech-start barge-in before turn-end emission
 - Implemented: stdin shell and microphone capture with preroll / hold / silence-based utterance detection
-- Implemented: automatic preference for headset-like external microphones when the system default input is built-in
-- Implemented: optional macOS application-audio capture that feeds STT and stores transcripts as application context instead of user speech, with `context_only` as the default mode
+- Implemented: automatic preference for higher-fidelity external microphones when the system default input is built-in, while avoiding Bluetooth hands-free inputs unless explicitly requested
+- Implemented: optional macOS per-app application-audio capture and Windows process-loopback application-audio capture, both feeding STT and storing transcripts as application context by default
 - Implemented: adaptive VAD and low-frequency-preserving STT-side speech enhancement for application audio
 - Implemented: mock STT, echo LLM, mock TTS, and in-memory playback for local development
 - Implemented: Moonshine STT via `moonshine-voice`
 - Implemented: Gemini `generateContent` integration over HTTPS
-- Implemented: trigger-based named-window screenshot capture for Gemini input on macOS
+- Implemented: trigger-based named-window screenshot capture for Gemini input on macOS and Windows
 - Implemented: AivisSpeech synthesis over the local HTTP API
+- Implemented: default speaker playback via `afplay` on macOS and PowerShell `SoundPlayer` on Windows
 - Implemented: sentence-by-sentence TTS playback with one-sentence-ahead prefetch
 - Implemented: optional transparent browser overlay with a character image, speech-only captions, and per-chunk text reveal timed to playback
 - Implemented: bounded LLM request compaction with an earlier-conversation summary plus a recent raw-message window
@@ -44,6 +45,13 @@ Run directly from the source tree:
 
 ```bash
 PYTHONPATH=src python3 -m vocalive
+```
+
+Windows PowerShell:
+
+```powershell
+$env:PYTHONPATH = "src"
+python -m vocalive
 ```
 
 Or install the package in editable mode:
@@ -79,23 +87,29 @@ export VOCALIVE_GEMINI_API_KEY=...
 PYTHONPATH=src python3 -m vocalive
 ```
 
+On Windows PowerShell, set the same variables with `$env:NAME = "value"` and run `python -m vocalive`.
+
 When `VOCALIVE_OVERLAY_ENABLED=true`, VocaLive starts a local overlay server and prints its URL. By default it also asks the system browser to open the page automatically. The overlay is transparent, renders the character on the right, and shows assistant text only while the assistant is actively speaking. Each sentence-sized chunk is revealed progressively to match playback timing, then cleared when playback finishes or is interrupted.
 
 Current runtime constraints:
 
 - live microphone or application-audio input currently requires `VOCALIVE_STT_PROVIDER=moonshine`
-- `VOCALIVE_APP_AUDIO_ENABLED=true` currently requires macOS, `VOCALIVE_APP_AUDIO_TARGET`, and Screen Recording permission
+- `VOCALIVE_APP_AUDIO_ENABLED=true` currently requires `VOCALIVE_APP_AUDIO_TARGET`; on macOS it also requires Screen Recording permission, and on Windows it requires `csc.exe` plus a Windows build with WASAPI process-loopback support
 - `VOCALIVE_OUTPUT_PROVIDER=speaker` currently requires `VOCALIVE_TTS_PROVIDER=aivis`
-- `VOCALIVE_SCREEN_CAPTURE_ENABLED=true` currently requires `VOCALIVE_MODEL_PROVIDER=gemini`, macOS, and Screen Recording permission
-- speaker playback uses `afplay {path}` by default on macOS; on other platforms set `VOCALIVE_SPEAKER_COMMAND`
+- `VOCALIVE_SCREEN_CAPTURE_ENABLED=true` currently requires `VOCALIVE_MODEL_PROVIDER=gemini`; on macOS it also requires Screen Recording permission, and on Windows it requires `csc.exe`
+- speaker playback uses `afplay {path}` by default on macOS and PowerShell `SoundPlayer` on Windows; on other platforms set `VOCALIVE_SPEAKER_COMMAND`
 - the overlay is local-only and driven by sentence playback events; it is not token streaming from the LLM
 - Gemini accepts either `VOCALIVE_GEMINI_API_KEY` or `GEMINI_API_KEY`
 - Gemini defaults to a surreal, deadpan conversation persona inspired by the vibe of Kamiusagi Rope; set `VOCALIVE_GEMINI_SYSTEM_INSTRUCTION` to override it, or set it to an empty string to disable it
 
+Windows supports the full `stdin` / `microphone` / `application audio` / `screen capture` / overlay / speaker path. On Windows, application audio uses WASAPI process loopback scoped to the selected process tree while the selected process remains alive.
+
+When microphone auto-selection is enabled, VocaLive avoids Bluetooth hands-free / AG Audio inputs by default because Windows often drops playback quality while those microphone profiles are active. If you need one anyway, set `VOCALIVE_MIC_DEVICE` explicitly.
+
 Microphone tuning notes:
 
-- `VOCALIVE_MIC_DEVICE=external` tells VocaLive to search for a currently connected headset-like external microphone
-- when `VOCALIVE_MIC_DEVICE` is unset and `VOCALIVE_MIC_PREFER_EXTERNAL=true`, VocaLive will switch away from a built-in default mic if it finds a better external input
+- `VOCALIVE_MIC_DEVICE=external` tells VocaLive to search for a currently connected external microphone, including Bluetooth hands-free inputs when they are the only match
+- when `VOCALIVE_MIC_DEVICE` is unset and `VOCALIVE_MIC_PREFER_EXTERNAL=true`, VocaLive will switch away from a built-in default mic if it finds a higher-fidelity external input; Bluetooth hands-free / AG Audio inputs are skipped by auto-selection because they commonly degrade Windows playback quality
 - if phrase starts are clipped, increase `VOCALIVE_MIC_PRE_SPEECH_MS`
 - if mid-sentence pauses cause early cuts, increase `VOCALIVE_MIC_SPEECH_HOLD_MS` and `VOCALIVE_MIC_SILENCE_MS`
 - after one live utterance is emitted, VocaLive waits briefly before queueing the LLM turn so closely spaced microphone utterances can merge; tune this with `VOCALIVE_REPLY_DEBOUNCE_MS`
@@ -108,13 +122,15 @@ Application-audio notes:
 - `VOCALIVE_APP_AUDIO_MODE=context_only` is the default; app audio is transcribed and appended to session history as labeled application context, but it does not immediately trigger LLM/TTS or interrupt active playback
 - older application-audio entries are compacted into a separate bounded summary while the newest configured app-context messages stay verbatim in the LLM request window
 - set `VOCALIVE_APP_AUDIO_MODE=respond` when you want application-audio utterances to behave like live turns and trigger immediate assistant replies
-- the configured target is matched against the running macOS application name first and bundle identifier second
+- on macOS, the configured target is matched against the running application name first and bundle identifier second
+- on Windows, the configured target is matched against process name first, executable path second, and main window title third
 - application audio uses adaptive energy-based VAD by default so steady BGM is more likely to stay in the background; set `VOCALIVE_APP_AUDIO_ADAPTIVE_VAD=false` to fall back to fixed thresholding
 - application-audio utterances go through STT like live user audio, but session history stores them as labeled application context such as `Application audio (Steam): ...`
 - default application-audio tuning keeps more preroll and trailing context so phrase starts and endings are less likely to clip; raise `VOCALIVE_APP_AUDIO_PRE_SPEECH_MS`, `VOCALIVE_APP_AUDIO_SPEECH_HOLD_MS`, or `VOCALIVE_APP_AUDIO_SILENCE_MS` further if one app still cuts too aggressively
 - Moonshine applies low-frequency-preserving enhancement with a gentle presence boost, soft gate, short edge padding, and normalization to application audio before STT by default; set `VOCALIVE_APP_AUDIO_STT_ENHANCEMENT=false` to disable it
 - in `respond` mode, application-audio speech start also interrupts stale assistant playback before the buffered utterance is fully emitted
-- app lookup and capture rely on a small ScreenCaptureKit helper that is built on first use
+- app lookup and capture rely on a small platform helper that is built on first use; macOS uses ScreenCaptureKit via `swiftc`, and Windows uses a C# helper via `csc.exe`
+- on Windows, capture uses WASAPI process loopback for the selected process tree, so other audible apps or VocaLive speaker playback on the same output device are excluded; this requires a Windows build with process-loopback support
 - if macOS Screen Recording permission is missing, app lookup or capture will time out/fail and the error is logged
 
 Screen-capture notes:
@@ -122,10 +138,11 @@ Screen-capture notes:
 - screen capture is request-scoped, not persistent session history
 - older user/assistant turns are compacted into one system summary when the request window grows past the configured raw-message count
 - capture is triggered only when the normalized user utterance contains one of the configured trigger phrases
-- the current implementation resolves the first on-screen window whose title or owner name matches `VOCALIVE_SCREEN_WINDOW_NAME`
+- the current implementation resolves the first on-screen window whose title or owner name matches `VOCALIVE_SCREEN_WINDOW_NAME` on macOS and Windows
 - captured screenshots are downscaled so the longest edge is at most `1280px` before they are attached to Gemini; set `VOCALIVE_SCREEN_RESIZE_MAX_EDGE_PX` empty to disable that
 - the resolved window id is cached and reused until capture fails, then looked up again
 - `VOCALIVE_SCREEN_WINDOW_NAME` is required when screen capture is enabled
+- macOS uses a small Objective-C helper plus `screencapture`; Windows uses a C# helper that captures the target window with `PrintWindow` and a `BitBlt` fallback
 - if macOS screen recording permission is missing, the turn falls back to text-only input and logs `screen_capture_failed`
 
 The stdin shell can also exercise the Gemini and Aivis wiring without a microphone. Typed input is stored as `AudioSegment.transcript_hint`, so a `moonshine` configuration can still run cleanly before you switch to live microphone mode. The first real Moonshine transcription downloads and caches the selected model files.
@@ -157,16 +174,16 @@ All runtime configuration is environment-driven.
 | `VOCALIVE_MIC_CHANNELS` | `1` | Captured microphone channel count |
 | `VOCALIVE_MIC_BLOCK_MS` | `40` | Duration of each captured PCM block |
 | `VOCALIVE_MIC_DEVICE` | unset | Optional input device id, device name, `default`, or `external` |
-| `VOCALIVE_MIC_PREFER_EXTERNAL` | `true` | Prefer a connected headset-like external mic when the default input looks built-in |
+| `VOCALIVE_MIC_PREFER_EXTERNAL` | `true` | Prefer a connected higher-fidelity external mic when the default input looks built-in; auto-selection avoids Bluetooth hands-free inputs |
 | `VOCALIVE_MIC_SPEECH_THRESHOLD` | `0.02` | RMS threshold for treating a block as speech |
 | `VOCALIVE_MIC_PRE_SPEECH_MS` | `200` | Audio kept before speech starts so utterance onsets are not clipped |
 | `VOCALIVE_MIC_SPEECH_HOLD_MS` | `200` | Keep an utterance in the speech state briefly after the threshold drops |
 | `VOCALIVE_MIC_SILENCE_MS` | `500` | Silence required before emitting the buffered utterance |
 | `VOCALIVE_MIC_MIN_UTTERANCE_MS` | `250` | Minimum buffered audio before end-of-turn detection may emit |
 | `VOCALIVE_MIC_MAX_UTTERANCE_MS` | `15000` | Hard cap for one buffered utterance |
-| `VOCALIVE_APP_AUDIO_ENABLED` | `false` | Enables macOS application-audio capture as an additional live input |
+| `VOCALIVE_APP_AUDIO_ENABLED` | `false` | Enables application-audio capture as an additional live input |
 | `VOCALIVE_APP_AUDIO_MODE` | `context_only` | `context_only` stores app transcripts in session without immediate assistant replies; `respond` makes app audio behave like normal live turns |
-| `VOCALIVE_APP_AUDIO_TARGET` | unset | Required application selector; matches running application name first, then bundle identifier |
+| `VOCALIVE_APP_AUDIO_TARGET` | unset | Required application selector; on macOS it matches application name first then bundle identifier, and on Windows it matches process name, executable path, or main window title |
 | `VOCALIVE_APP_AUDIO_SAMPLE_RATE` | `16000` | Application-audio capture sample rate after helper-side conversion |
 | `VOCALIVE_APP_AUDIO_CHANNELS` | `1` | Captured application-audio channel count |
 | `VOCALIVE_APP_AUDIO_BLOCK_MS` | `40` | Duration of each buffered application-audio PCM block |
@@ -176,7 +193,7 @@ All runtime configuration is environment-driven.
 | `VOCALIVE_APP_AUDIO_SILENCE_MS` | `650` | Silence required before emitting a buffered application-audio utterance |
 | `VOCALIVE_APP_AUDIO_MIN_UTTERANCE_MS` | `250` | Minimum buffered application audio before end-of-turn detection may emit |
 | `VOCALIVE_APP_AUDIO_MAX_UTTERANCE_MS` | `15000` | Hard cap for one buffered application-audio utterance |
-| `VOCALIVE_APP_AUDIO_TIMEOUT_SECONDS` | `10` | Timeout for macOS app lookup, helper startup, and helper build floor |
+| `VOCALIVE_APP_AUDIO_TIMEOUT_SECONDS` | `10` | Timeout for application lookup, helper startup, and helper build floor |
 | `VOCALIVE_APP_AUDIO_ADAPTIVE_VAD` | `true` | Enables adaptive energy-based VAD for application audio; `false` falls back to fixed thresholding |
 | `VOCALIVE_APP_AUDIO_STT_ENHANCEMENT` | `true` | Enables lightweight application-audio speech enhancement before Moonshine STT |
 | `VOCALIVE_STT_PROVIDER` | `mock` | STT adapter; accepts `moonshine` and aliases such as `moonshine voice` |
@@ -208,7 +225,7 @@ All runtime configuration is environment-driven.
 | `VOCALIVE_SCREEN_CAPTURE_ENABLED` | `false` | Enables request-scoped named-window screenshot capture for Gemini turns |
 | `VOCALIVE_SCREEN_WINDOW_NAME` | unset | Required window selector; matches on-screen window title first, then owner name |
 | `VOCALIVE_SCREEN_TRIGGER_PHRASES` | `画面みて,画面見て,画面をみて,画面を見て,スクショみて,スクショ見て` | Comma-separated trigger phrases that cause a screenshot to be attached |
-| `VOCALIVE_SCREEN_CAPTURE_TIMEOUT_SECONDS` | `5` | Timeout for macOS window lookup and `screencapture` |
+| `VOCALIVE_SCREEN_CAPTURE_TIMEOUT_SECONDS` | `5` | Timeout for window lookup and platform capture helpers |
 | `VOCALIVE_SCREEN_RESIZE_MAX_EDGE_PX` | `1280` | Resizes captured screenshots so their longest edge stays within this many pixels; empty disables resizing |
 | `VOCALIVE_MOONSHINE_MODEL` | `base` | Moonshine model architecture such as `base` / `tiny`, or a concrete model id such as `base-ja` |
 | `VOCALIVE_AIVIS_BASE_URL` | `http://127.0.0.1:10101` | AivisSpeech engine base URL |
@@ -216,7 +233,7 @@ All runtime configuration is environment-driven.
 | `VOCALIVE_AIVIS_SPEAKER_NAME` | unset | Speaker name to resolve via `/speakers` |
 | `VOCALIVE_AIVIS_STYLE_NAME` | unset | Style name to resolve via `/speakers` |
 | `VOCALIVE_AIVIS_TIMEOUT_SECONDS` | `30` | AivisSpeech API timeout |
-| `VOCALIVE_SPEAKER_COMMAND` | `afplay {path}` | Override playback command; must include `{path}` |
+| `VOCALIVE_SPEAKER_COMMAND` | platform default | Override playback command; must include `{path}`. Defaults to `afplay {path}` on macOS and PowerShell `SoundPlayer` on Windows |
 | `VOCALIVE_QUEUE_MAXSIZE` | `4` | Maximum queued utterances waiting to run |
 | `VOCALIVE_QUEUE_OVERFLOW` | `drop_oldest` | Overflow strategy: `drop_oldest` or `reject_new` |
 
@@ -228,12 +245,13 @@ Current provider support:
 - `moonshine` uses the optional `moonshine-voice` package for STT and applies low-frequency-preserving enhancement to application audio before transcription by default
 - `VOCALIVE_MOONSHINE_MODEL=base` resolves a language-specific Moonshine model from `VOCALIVE_CONVERSATION_LANGUAGE`, so the default Japanese configuration resolves to `base-ja`
 - `gemini` uses the Gemini `generateContent` API over HTTPS; the default config sets `thinkingBudget=0` to reduce latency
-- optional application-audio capture resolves one running macOS app, segments its audio into utterances, and by default submits those transcripts as labeled application context without immediate assistant replies
+- optional application-audio capture resolves one named running app, segments audio into utterances, and by default submits those transcripts as labeled application context without immediate assistant replies
 - older application-audio context is compacted into one bounded system summary while the newest configured app-audio messages remain verbatim in requests
-- optional screen capture resolves a named on-screen window on macOS and attaches one PNG of that window to the current Gemini turn when a trigger phrase matches
+- on macOS, application-audio capture uses ScreenCaptureKit to isolate the selected app; on Windows, application-audio capture uses WASAPI process loopback for the selected process tree while the selected process remains alive
+- optional screen capture resolves a named on-screen window on macOS or Windows and attaches one PNG of that window to the current Gemini turn when a trigger phrase matches
 - older user/assistant dialogue is compacted into one bounded system summary before Gemini requests so long sessions do not resend the entire raw conversation every turn
 - `aivis` uses the local AivisSpeech engine API and resolves a style id from `/speakers` when needed
-- `speaker` output plays synthesized audio through the configured external command
+- `speaker` output plays synthesized audio through the configured external command or the platform default playback command
 - `overlay` is an optional local browser UI fed by orchestrator events and chunk-level playback timing
 - the overlay loads character art from `src/vocalive/ui/assets/character.png` when present, and otherwise falls back to the built-in vector character
 - provider names are normalized case-insensitively, so values such as `Moonshine Voice` and `Aivis Speech` resolve to the supported adapters

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ Before closing a documentation-related change, verify:
 2. Provider support and compatibility constraints match the actual assembly code.
 3. Configuration names and defaults match `src/vocalive/config/settings.py`.
 4. Coverage statements still reflect what exists in `tests/unit/`.
-5. Platform-specific or optional requirements such as `afplay` and `moonshine-voice` are called out explicitly.
+5. Platform-specific or optional requirements such as `afplay`, PowerShell playback, `csc.exe`, and `moonshine-voice` are called out explicitly.
 6. Overlay behavior, transparency, and asset paths still match `src/vocalive/ui/overlay.py`.
 7. Future ideas are labeled as future work, not present-tense behavior.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ The current entry point supports two primary input modes plus an optional extra 
 2. `microphone`
    `MicrophoneAudioInput` captures `int16` PCM through `sounddevice`, applies preroll / speech-hold / silence thresholds, and emits utterance-sized `AudioSegment` instances.
 3. `application audio` (optional)
-   `MacOSApplicationAudioInput` captures one running macOS app through a ScreenCaptureKit helper, applies adaptive speech detection by default plus local utterance segmentation, and emits utterance-sized `AudioSegment` instances tagged as application audio. The default `context_only` mode stores those transcripts as session context without immediate assistant replies; `respond` opt-in restores live-turn behavior.
+   `MacOSApplicationAudioInput` captures one running macOS app through a ScreenCaptureKit helper, while `WindowsApplicationAudioInput` resolves a named Windows process and records WASAPI process loopback for that process tree while the selected process remains alive. Both apply adaptive speech detection by default plus local utterance segmentation and emit utterance-sized `AudioSegment` instances tagged as application audio. The default `context_only` mode stores those transcripts as session context without immediate assistant replies; `respond` opt-in restores live-turn behavior.
 
 ## Current runtime flow
 
@@ -76,12 +76,14 @@ The orchestration logic lives in `src/vocalive/pipeline/orchestrator.py`.
 | `audio/devices.py` | Input device resolution, default-device lookup, and headset/external microphone preference |
 | `audio/input.py` | Stdin-like queue input, microphone capture, combined live-input fan-in, utterance accumulation, and speech-start callbacks |
 | `audio/macos_application.py` | macOS application-audio helper build, app lookup, capture, and utterance emission |
+| `audio/windows_application.py` | Windows application-audio helper build, process lookup, process-loopback capture, and utterance emission |
 | `audio/speech_detection.py` | Fixed-threshold and adaptive speech detectors used before utterance segmentation |
 | `audio/output.py` | Playback abstraction, in-memory output, and external speaker command playback |
 | `audio/vad.py` | Turn detection abstraction; current live path uses fixed-silence detection |
 | `stt/` | Speech-to-text interface and adapters, including Moonshine application-audio enhancement |
 | `llm/` | Language model interface and adapters |
 | `screen/` | Optional named-window screenshot capture adapters |
+| `screen/windows.py` | Windows window lookup, helper build, and named-window PNG capture |
 | `tts/` | Text-to-speech interface and adapters |
 | `pipeline/queues.py` | Bounded ingress queue with explicit overflow policy |
 | `pipeline/interruption.py` | Cancellation token and active-turn interruption control |
@@ -150,7 +152,8 @@ Optional real adapters:
 
 - `MoonshineSpeechToTextEngine`
 - `GeminiLanguageModel`
-- `MacOSFullscreenScreenCapture`
+- `MacOSWindowScreenCapture`
+- `WindowsWindowScreenCapture`
 - `AivisSpeechTextToSpeechEngine`
 - `SpeakerAudioOutput`
 
@@ -166,12 +169,14 @@ Current compatibility constraints:
 
 - microphone or application-audio input is rejected when STT is still `mock`
 - application-audio input is rejected unless `VOCALIVE_APP_AUDIO_TARGET` is configured
-- application-audio input currently supports macOS only and depends on Screen Recording permission plus a first-run helper build
+- application-audio input currently supports macOS and Windows
+- on macOS, application-audio capture depends on Screen Recording permission plus a first-run helper build
+- on Windows, application-audio capture depends on `csc.exe` plus a Windows build with WASAPI process-loopback support and isolates the selected process tree from other audible apps on the same device
 - speaker output is rejected unless TTS is `aivis`
 - screen capture is rejected unless the model provider is `gemini`
 - screen capture is rejected unless `VOCALIVE_SCREEN_WINDOW_NAME` is configured
-- screen capture currently supports macOS only and resolves the first on-screen window that matches the configured title or owner name
-- speaker playback depends on an external playback command and defaults to `afplay` on macOS
+- screen capture currently supports macOS and Windows and resolves the first on-screen window that matches the configured title or owner name
+- speaker playback depends on an external playback command and defaults to `afplay` on macOS and PowerShell `SoundPlayer` on Windows
 
 The stdin shell still works with the real-provider assembly because `AudioSegment.from_text()` sets `transcript_hint`, and the Moonshine adapter short-circuits to that hint before touching the backend.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,6 +10,15 @@ python3 -m unittest discover -s tests -v
 python3 -m compileall src tests
 ```
 
+Windows PowerShell:
+
+```powershell
+$env:PYTHONPATH = "src"
+python -m vocalive
+python -m unittest discover -s tests -v
+python -m compileall src tests
+```
+
 Editable install is optional:
 
 ```bash
@@ -31,11 +40,11 @@ The current entry point is `src/vocalive/main.py`.
 - `VOCALIVE_INPUT_PROVIDER=stdin` keeps the text shell
 - `VOCALIVE_INPUT_PROVIDER=microphone` uses `sounddevice` and local utterance detection
 - live microphone or application-audio input currently requires `VOCALIVE_STT_PROVIDER=moonshine`
-- `VOCALIVE_APP_AUDIO_ENABLED=true` layers macOS application-audio capture on top of either `stdin` or `microphone`
+- `VOCALIVE_APP_AUDIO_ENABLED=true` layers application-audio capture on top of either `stdin` or `microphone`
 - `VOCALIVE_APP_AUDIO_MODE=context_only` is the default; application-audio segments are transcribed and appended to session history without immediately triggering LLM/TTS
 - set `VOCALIVE_APP_AUDIO_MODE=respond` when you want application audio to behave like a normal live turn and interrupt stale playback
 - application-audio turns are stored in session history as labeled application context, not as user messages
-- application-audio capture currently requires macOS, `VOCALIVE_APP_AUDIO_TARGET`, and Screen Recording permission
+- application-audio capture currently requires `VOCALIVE_APP_AUDIO_TARGET`; on macOS it also requires Screen Recording permission, and on Windows it requires `csc.exe` plus a Windows build with WASAPI process-loopback support
 - application-audio capture uses adaptive energy-based VAD by default and can fall back to fixed thresholding with `VOCALIVE_APP_AUDIO_ADAPTIVE_VAD=false`
 - Moonshine applies low-frequency-preserving speech enhancement to application-audio segments before transcription unless `VOCALIVE_APP_AUDIO_STT_ENHANCEMENT=false`
 - `VOCALIVE_OUTPUT_PROVIDER=speaker` currently requires `VOCALIVE_TTS_PROVIDER=aivis`
@@ -51,17 +60,21 @@ The current entry point is `src/vocalive/main.py`.
 - microphone user utterances wait for `VOCALIVE_REPLY_DEBOUNCE_MS` before queueing so closely spaced follow-up speech can merge into one LLM turn
 - microphone reply suppression is enabled by default for low-value live chatter; explicit questions/requests still bypass the policy
 - older application-audio context is compacted into its own bounded summary while the newest configured app-audio messages stay verbatim in Gemini requests
-- `VOCALIVE_MIC_DEVICE=external` forces selection of a connected headset-like external mic
-- when `VOCALIVE_MIC_DEVICE` is unset and `VOCALIVE_MIC_PREFER_EXTERNAL=true`, VocaLive prefers a connected external mic over a built-in default input
+- `VOCALIVE_MIC_DEVICE=external` forces selection of a connected external mic, including Bluetooth hands-free inputs when they are the best match
+- when `VOCALIVE_MIC_DEVICE` is unset and `VOCALIVE_MIC_PREFER_EXTERNAL=true`, VocaLive prefers a connected higher-fidelity external mic over a built-in default input and skips Bluetooth hands-free / AG Audio inputs during auto-selection
 - the microphone path uses local RMS thresholding plus silence timing, not a production VAD
 - the stdin shell sets `AudioSegment.transcript_hint`, so `moonshine`-selected configs can still exercise Gemini and Aivis wiring before switching to live microphone capture
 - when screen capture is enabled, configured trigger phrases attach one screenshot of the configured window to the current Gemini turn only
 
-Speaker playback uses `afplay {path}` by default on macOS. On other platforms, set `VOCALIVE_SPEAKER_COMMAND` to a command template that includes `{path}`.
+Speaker playback uses `afplay {path}` by default on macOS and PowerShell `SoundPlayer` on Windows. On other platforms, set `VOCALIVE_SPEAKER_COMMAND` to a command template that includes `{path}`.
 
-Screen capture currently uses the macOS `screencapture` command, resolves the configured on-screen window by title or owner name, and requires Screen Recording permission.
+Windows supports the full `stdin` / `microphone` / `application audio` / `screen capture` / overlay / speaker path. On Windows, application audio records WASAPI process loopback scoped to the selected process tree while the selected process remains alive.
 
-Application-audio capture currently uses a small ScreenCaptureKit helper compiled on first use, resolves one running app by name or bundle identifier, and also requires Screen Recording permission.
+On Windows, Bluetooth hands-free microphone profiles often force headset playback into low-fidelity call mode while the mic is active. VocaLive therefore avoids auto-selecting those inputs unless `VOCALIVE_MIC_DEVICE` is set explicitly.
+
+Screen capture resolves the configured on-screen window by title or owner name. macOS uses `screencapture` and requires Screen Recording permission; Windows uses a small C# helper built with `csc.exe`.
+
+Application-audio capture uses a small helper compiled on first use. macOS uses ScreenCaptureKit and resolves one running app by name or bundle identifier; Windows resolves a process name, executable path, or window title and captures WASAPI process loopback for that process tree while the selected process stays alive.
 
 ## Configuration
 
@@ -76,16 +89,16 @@ Runtime settings are loaded from `AppSettings.from_env()` in `src/vocalive/confi
 | `VOCALIVE_MIC_CHANNELS` | `1` | Captured microphone channel count |
 | `VOCALIVE_MIC_BLOCK_MS` | `40` | Duration of each captured PCM block |
 | `VOCALIVE_MIC_DEVICE` | unset | Optional input device id, device name, `default`, or `external` |
-| `VOCALIVE_MIC_PREFER_EXTERNAL` | `true` | Prefer a connected headset-like external mic when the default input looks built-in |
+| `VOCALIVE_MIC_PREFER_EXTERNAL` | `true` | Prefer a connected higher-fidelity external mic when the default input looks built-in; auto-selection skips Bluetooth hands-free inputs |
 | `VOCALIVE_MIC_SPEECH_THRESHOLD` | `0.02` | RMS threshold for treating a block as speech |
 | `VOCALIVE_MIC_PRE_SPEECH_MS` | `200` | Audio kept before speech starts so utterance onsets are not clipped |
 | `VOCALIVE_MIC_SPEECH_HOLD_MS` | `200` | Keeps an utterance in the speech state briefly after the threshold drops |
 | `VOCALIVE_MIC_SILENCE_MS` | `500` | Silence required before the live path emits a buffered utterance |
 | `VOCALIVE_MIC_MIN_UTTERANCE_MS` | `250` | Minimum buffered audio before turn-end emission is allowed |
 | `VOCALIVE_MIC_MAX_UTTERANCE_MS` | `15000` | Hard cap for one buffered utterance |
-| `VOCALIVE_APP_AUDIO_ENABLED` | `false` | Enables macOS application-audio capture as an extra live source |
+| `VOCALIVE_APP_AUDIO_ENABLED` | `false` | Enables application-audio capture as an extra live source |
 | `VOCALIVE_APP_AUDIO_MODE` | `context_only` | `context_only` stores app transcripts as session context only; `respond` makes app audio trigger live assistant turns |
-| `VOCALIVE_APP_AUDIO_TARGET` | unset | Required selector matched against running application name first, then bundle identifier |
+| `VOCALIVE_APP_AUDIO_TARGET` | unset | Required selector. macOS matches application name first then bundle identifier; Windows matches process name, executable path, or main window title |
 | `VOCALIVE_APP_AUDIO_SAMPLE_RATE` | `16000` | Application-audio sample rate after helper-side conversion |
 | `VOCALIVE_APP_AUDIO_CHANNELS` | `1` | Captured application-audio channel count |
 | `VOCALIVE_APP_AUDIO_BLOCK_MS` | `40` | Duration of each buffered application-audio PCM block |
@@ -127,7 +140,7 @@ Runtime settings are loaded from `AppSettings.from_env()` in `src/vocalive/confi
 | `VOCALIVE_SCREEN_CAPTURE_ENABLED` | `false` | Enables request-scoped named-window screenshot capture for Gemini turns |
 | `VOCALIVE_SCREEN_WINDOW_NAME` | unset | Required selector matched against on-screen window title first, then owner name |
 | `VOCALIVE_SCREEN_TRIGGER_PHRASES` | `画面みて,画面見て,画面をみて,画面を見て,スクショみて,スクショ見て` | Comma-separated trigger phrases matched against the normalized utterance |
-| `VOCALIVE_SCREEN_CAPTURE_TIMEOUT_SECONDS` | `5` | Timeout for macOS window lookup and `screencapture` |
+| `VOCALIVE_SCREEN_CAPTURE_TIMEOUT_SECONDS` | `5` | Timeout for window lookup and platform capture helpers |
 | `VOCALIVE_SCREEN_RESIZE_MAX_EDGE_PX` | `1280` | Resizes captured screenshots so their longest edge stays within this many pixels; empty disables resizing |
 | `VOCALIVE_MOONSHINE_MODEL` | `base` | Moonshine architecture such as `base` / `tiny`, or a concrete model id such as `base-ja` |
 | `VOCALIVE_AIVIS_BASE_URL` | `http://127.0.0.1:10101` | Local AivisSpeech engine base URL |
@@ -135,7 +148,7 @@ Runtime settings are loaded from `AppSettings.from_env()` in `src/vocalive/confi
 | `VOCALIVE_AIVIS_SPEAKER_NAME` | unset | Optional speaker name for `/speakers` lookup |
 | `VOCALIVE_AIVIS_STYLE_NAME` | unset | Optional style name for `/speakers` lookup |
 | `VOCALIVE_AIVIS_TIMEOUT_SECONDS` | `30` | AivisSpeech API timeout |
-| `VOCALIVE_SPEAKER_COMMAND` | `afplay {path}` | Override playback command; must include `{path}` |
+| `VOCALIVE_SPEAKER_COMMAND` | platform default | Override playback command; must include `{path}`. Defaults to `afplay {path}` on macOS and PowerShell `SoundPlayer` on Windows |
 | `VOCALIVE_QUEUE_MAXSIZE` | `4` | Bounded utterance backlog |
 | `VOCALIVE_QUEUE_OVERFLOW` | `drop_oldest` | `drop_oldest` or `reject_new` |
 
@@ -161,7 +174,7 @@ Screen capture can be layered on combinations 2 and 3 when:
 
 - `VOCALIVE_SCREEN_CAPTURE_ENABLED=true`
 - `VOCALIVE_MODEL_PROVIDER=gemini`
-- the app is running on macOS with Screen Recording permission
+- the app is running on macOS with Screen Recording permission, or on Windows with `csc.exe` available
 
 The second combination is useful because the stdin shell supplies `transcript_hint`, which lets the real-provider assembly come up before the live microphone path is enabled.
 

--- a/src/vocalive/audio/devices.py
+++ b/src/vocalive/audio/devices.py
@@ -13,16 +13,21 @@ _EXTERNAL_DEVICE_ALIASES = {
     "headphones",
 }
 _HEADSET_DEVICE_KEYWORDS = (
-    "airpods",
-    "bluetooth",
     "earbud",
     "earbuds",
-    "hands free",
-    "handsfree",
     "headphone",
     "headphones",
     "headset",
     "wireless",
+)
+_LOW_FIDELITY_COMMUNICATION_DEVICE_KEYWORDS = (
+    "ag audio",
+    "hands free",
+    "handsfree",
+)
+_LOW_FIDELITY_BLUETOOTH_DEVICE_KEYWORDS = (
+    "airpods",
+    "bluetooth",
 )
 _EXTERNAL_DEVICE_KEYWORDS = (
     "adapter",
@@ -223,11 +228,27 @@ def _select_external_input_device(
 def _external_device_confidence(normalized_name: str) -> int:
     if _looks_builtin_input(normalized_name):
         return -1
+    if _looks_low_fidelity_communication_input(normalized_name):
+        return 0
     if any(keyword in normalized_name for keyword in _HEADSET_DEVICE_KEYWORDS):
-        return 2
-    if any(keyword in normalized_name for keyword in _EXTERNAL_DEVICE_KEYWORDS):
         return 1
+    if any(keyword in normalized_name for keyword in _EXTERNAL_DEVICE_KEYWORDS):
+        return 2
+    if any(keyword in normalized_name for keyword in _LOW_FIDELITY_BLUETOOTH_DEVICE_KEYWORDS):
+        return 0
     return 0
+
+
+def _looks_low_fidelity_communication_input(normalized_name: str) -> bool:
+    if any(
+        keyword in normalized_name
+        for keyword in _LOW_FIDELITY_COMMUNICATION_DEVICE_KEYWORDS
+    ):
+        return True
+    return any(
+        keyword in normalized_name
+        for keyword in _LOW_FIDELITY_BLUETOOTH_DEVICE_KEYWORDS
+    ) and any(keyword in normalized_name for keyword in _HEADSET_DEVICE_KEYWORDS)
 
 
 def _looks_builtin_input(normalized_name: str) -> bool:

--- a/src/vocalive/audio/input.py
+++ b/src/vocalive/audio/input.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import importlib
+import queue
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Awaitable, Callable
@@ -305,6 +306,8 @@ class MicrophoneAudioInput(AudioInput):
         )
         self._stream: Any | None = None
         self._selected_device: InputDeviceMatch | None = None
+        self._chunk_queue: queue.Queue[bytes | None] = queue.Queue(maxsize=32)
+        self._dropped_chunk_count = 0
         self._closed = False
 
     async def start(self) -> str:
@@ -314,16 +317,18 @@ class MicrophoneAudioInput(AudioInput):
     async def read(self) -> AudioSegment | None:
         if self._closed:
             return None
-        stream = self._ensure_stream()
-        while not self._closed:
-            chunk = await asyncio.to_thread(self._read_chunk, stream)
+        self._ensure_stream()
+        while True:
+            chunk = await asyncio.to_thread(self._read_chunk)
+            if chunk is None:
+                return self._accumulator.flush()
             segment = self._accumulator.add_chunk(chunk)
             if segment is not None:
                 return segment
-        return self._accumulator.flush()
 
     async def close(self) -> None:
         self._closed = True
+        self._signal_reader_shutdown()
         stream = self._stream
         self._stream = None
         if stream is None:
@@ -370,9 +375,10 @@ class MicrophoneAudioInput(AudioInput):
             device=selected_device.index,
             channels=self.channels,
             dtype="int16",
+            callback=self._handle_stream_chunk,
         )
-        stream.start()
         self._selected_device = selected_device
+        stream.start()
         log_event(
             logger,
             "microphone_stream_started",
@@ -385,12 +391,42 @@ class MicrophoneAudioInput(AudioInput):
         self._stream = stream
         return stream
 
-    def _read_chunk(self, stream: Any) -> bytes:
-        chunk, overflowed = stream.read(self.frames_per_block)
-        if overflowed:
-            # Preserve the chunk even when the backend reports an overrun.
-            return bytes(chunk)
-        return bytes(chunk)
+    def _handle_stream_chunk(
+        self,
+        indata: Any,
+        frames: int,
+        time_info: Any,
+        status: Any,
+    ) -> None:
+        del frames, time_info, status
+        if self._closed:
+            return
+        self._push_chunk(bytes(indata))
+
+    def _read_chunk(self) -> bytes | None:
+        return self._chunk_queue.get()
+
+    def _push_chunk(self, chunk: bytes | None) -> None:
+        while True:
+            try:
+                self._chunk_queue.put_nowait(chunk)
+                return
+            except queue.Full:
+                try:
+                    self._chunk_queue.get_nowait()
+                except queue.Empty:
+                    return
+                if chunk is not None:
+                    self._dropped_chunk_count += 1
+                    if self._dropped_chunk_count == 1:
+                        log_event(
+                            logger,
+                            "microphone_chunk_queue_overflow",
+                            device=self.selected_device_label,
+                        )
+
+    def _signal_reader_shutdown(self) -> None:
+        self._push_chunk(None)
 
     async def _wait_for_background_tasks(self) -> None:
         if not self._background_tasks:

--- a/src/vocalive/audio/output.py
+++ b/src/vocalive/audio/output.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import shlex
 import shutil
+import sys
 import tempfile
 from abc import ABC, abstractmethod
 from math import ceil
@@ -122,13 +123,30 @@ class SpeakerAudioOutput(AudioOutput):
 
 
 def _default_playback_command() -> list[str]:
-    afplay = shutil.which("afplay")
-    if afplay is None:
-        raise RuntimeError(
-            "speaker output requires a playback command. "
-            "On macOS `afplay` is used by default; otherwise set VOCALIVE_SPEAKER_COMMAND."
+    if sys.platform == "darwin":
+        afplay = shutil.which("afplay")
+        if afplay is not None:
+            return [afplay, "{path}"]
+    elif sys.platform == "win32":
+        powershell = (
+            shutil.which("powershell.exe")
+            or shutil.which("powershell")
+            or shutil.which("pwsh.exe")
+            or shutil.which("pwsh")
         )
-    return [afplay, "{path}"]
+        if powershell is not None:
+            return [
+                powershell,
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "(New-Object System.Media.SoundPlayer '{path}').PlaySync()",
+            ]
+    raise RuntimeError(
+        "speaker output requires a playback command. "
+        "On macOS `afplay` is used by default; on Windows PowerShell "
+        "`SoundPlayer` is used by default; otherwise set VOCALIVE_SPEAKER_COMMAND."
+    )
 
 
 def parse_playback_command(command: str | None) -> tuple[str, ...] | None:

--- a/src/vocalive/audio/speech_detection.py
+++ b/src/vocalive/audio/speech_detection.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import array
-import audioop
 import math
 import sys
 from abc import ABC, abstractmethod
@@ -118,10 +117,7 @@ class AdaptiveEnergySpeechDetector(SpeechDetector):
         return is_speech
 
     def _preemphasized_rms(self, chunk: bytes) -> float:
-        samples = array.array("h")
-        samples.frombytes(chunk)
-        if sys.byteorder != "little":
-            samples.byteswap()
+        samples = _read_pcm16_samples(chunk)
         if not samples:
             return 0.0
         total = 0.0
@@ -135,10 +131,7 @@ class AdaptiveEnergySpeechDetector(SpeechDetector):
         return math.sqrt(total / len(samples)) / _PCM16_MAX_ABS
 
     def _waveform_texture(self, chunk: bytes, raw_energy: float) -> float:
-        samples = array.array("h")
-        samples.frombytes(chunk)
-        if sys.byteorder != "little":
-            samples.byteswap()
+        samples = _read_pcm16_samples(chunk)
         if len(samples) < 2:
             return self.minimum_texture
         total_delta = 0.0
@@ -169,6 +162,33 @@ class AdaptiveEnergySpeechDetector(SpeechDetector):
 def _normalized_rms(chunk: bytes, sample_width_bytes: int) -> float:
     if not chunk:
         return 0.0
+    if sample_width_bytes <= 0:
+        raise ValueError("sample_width_bytes must be greater than zero")
+    usable_length = len(chunk) - (len(chunk) % sample_width_bytes)
+    if usable_length == 0:
+        return 0.0
     max_amplitude = float(1 << (8 * sample_width_bytes - 1))
-    rms = audioop.rms(chunk, sample_width_bytes)
-    return rms / max_amplitude
+    if sample_width_bytes == 2:
+        samples = _read_pcm16_samples(chunk[:usable_length])
+    else:
+        samples = [
+            int.from_bytes(
+                chunk[offset : offset + sample_width_bytes],
+                byteorder="little",
+                signed=True,
+            )
+            for offset in range(0, usable_length, sample_width_bytes)
+        ]
+    if not samples:
+        return 0.0
+    mean_square = sum(float(sample) * float(sample) for sample in samples) / len(samples)
+    return math.sqrt(mean_square) / max_amplitude
+
+
+def _read_pcm16_samples(chunk: bytes) -> array.array:
+    usable_length = len(chunk) - (len(chunk) % 2)
+    samples = array.array("h")
+    samples.frombytes(chunk[:usable_length])
+    if sys.byteorder != "little":
+        samples.byteswap()
+    return samples

--- a/src/vocalive/audio/windows_application.py
+++ b/src/vocalive/audio/windows_application.py
@@ -1,0 +1,804 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import inspect
+import json
+import tempfile
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from vocalive.audio.input import AudioInput, UtteranceAccumulator
+from vocalive.audio.speech_detection import AdaptiveEnergySpeechDetector
+from vocalive.audio.vad import FixedSilenceTurnDetector
+from vocalive.models import AudioSegment
+from vocalive.util.logging import get_logger, log_event
+from vocalive.util.windows_csharp import (
+    communicate_with_cancellation,
+    ensure_csharp_helper,
+    terminate_process,
+)
+
+
+logger = get_logger(__name__)
+
+_APPLICATION_AUDIO_HELPER_BUILD_TIMEOUT_FLOOR_SECONDS = 20.0
+_APPLICATION_AUDIO_HELPER_DIR = Path(tempfile.gettempdir()) / "vocalive-application-audio"
+_APPLICATION_AUDIO_HELPER_SOURCE = r"""
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Threading;
+
+[DataContract]
+internal sealed class ApplicationInfo {
+    [DataMember(Name = "processId")]
+    public int ProcessId { get; set; }
+
+    [DataMember(Name = "applicationName")]
+    public string ApplicationName { get; set; }
+
+    [DataMember(Name = "bundleIdentifier")]
+    public string BundleIdentifier { get; set; }
+
+    [DataMember(Name = "windowTitle")]
+    public string WindowTitle { get; set; }
+}
+
+[Flags]
+internal enum AudioClientStreamFlags : uint {
+    Loopback = 0x00020000,
+    EventCallback = 0x00040000,
+}
+
+[Flags]
+internal enum AudioClientBufferFlags : uint {
+    Silent = 0x2,
+}
+
+internal enum AudioClientShareMode {
+    Shared = 0,
+}
+
+internal enum AUDIOCLIENT_ACTIVATION_TYPE {
+    AUDIOCLIENT_ACTIVATION_TYPE_DEFAULT = 0,
+    AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK = 1,
+}
+
+internal enum PROCESS_LOOPBACK_MODE {
+    PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE = 0,
+    PROCESS_LOOPBACK_MODE_EXCLUDE_TARGET_PROCESS_TREE = 1,
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS {
+    public uint TargetProcessId;
+    public PROCESS_LOOPBACK_MODE ProcessLoopbackMode;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct AUDIOCLIENT_ACTIVATION_PARAMS {
+    public AUDIOCLIENT_ACTIVATION_TYPE ActivationType;
+    public AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS ProcessLoopbackParams;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct BLOB {
+    public uint cbSize;
+    public IntPtr pBlobData;
+}
+
+[StructLayout(LayoutKind.Explicit)]
+internal struct PROPVARIANT {
+    [FieldOffset(0)]
+    public ushort vt;
+
+    [FieldOffset(2)]
+    public ushort wReserved1;
+
+    [FieldOffset(4)]
+    public ushort wReserved2;
+
+    [FieldOffset(6)]
+    public ushort wReserved3;
+
+    [FieldOffset(8)]
+    public BLOB blob;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct WAVEFORMATEX {
+    public ushort wFormatTag;
+    public ushort nChannels;
+    public uint nSamplesPerSec;
+    public uint nAvgBytesPerSec;
+    public ushort nBlockAlign;
+    public ushort wBitsPerSample;
+    public ushort cbSize;
+}
+
+[ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2")]
+internal interface IAudioClient {
+    int Initialize(AudioClientShareMode shareMode, AudioClientStreamFlags streamFlags, long hnsBufferDuration, long hnsPeriodicity, IntPtr format, IntPtr audioSessionGuid);
+    int GetBufferSize(out uint bufferSize);
+    int GetStreamLatency(out long streamLatency);
+    int GetCurrentPadding(out uint currentPadding);
+    int IsFormatSupported(AudioClientShareMode shareMode, IntPtr format, IntPtr closestMatchFormat);
+    int GetMixFormat(out IntPtr deviceFormatPointer);
+    int GetDevicePeriod(out long defaultDevicePeriod, out long minimumDevicePeriod);
+    int Start();
+    int Stop();
+    int Reset();
+    int SetEventHandle(IntPtr eventHandle);
+    int GetService(ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out IAudioCaptureClient captureClient);
+}
+
+[ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("C8ADBD64-E71E-48a0-A4DE-185C395CD317")]
+internal interface IAudioCaptureClient {
+    int GetBuffer(out IntPtr data, out uint frameCount, out AudioClientBufferFlags flags, out ulong devicePosition, out ulong qpcPosition);
+    int ReleaseBuffer(uint frameCount);
+    int GetNextPacketSize(out uint packetSize);
+}
+
+[ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("41D949AB-9862-444A-80F6-C261334DA5EB")]
+internal interface IActivateAudioInterfaceCompletionHandler {
+    int ActivateCompleted(IActivateAudioInterfaceAsyncOperation activateOperation);
+}
+
+[ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("72A22D78-CDE4-431D-B8CC-843A71199B6D")]
+internal interface IActivateAudioInterfaceAsyncOperation {
+    int GetActivateResult(out int activateResult, [MarshalAs(UnmanagedType.IUnknown)] out object activatedInterface);
+}
+
+[ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("94EA2B94-E9CC-49E0-C0FF-EE64CA8F5B90")]
+internal interface IAgileObject {
+}
+
+[ComVisible(true)]
+internal sealed class ActivateAudioInterfaceCompletionHandler : IActivateAudioInterfaceCompletionHandler, IAgileObject, IDisposable {
+    private readonly AutoResetEvent completedEvent = new AutoResetEvent(false);
+    private int activateResult = unchecked((int)0x80004005);
+    private object activatedInterface;
+
+    public int ActivateCompleted(IActivateAudioInterfaceAsyncOperation activateOperation) {
+        try {
+            int activationHr;
+            object activationInterface;
+            int operationHr = activateOperation.GetActivateResult(out activationHr, out activationInterface);
+            activateResult = operationHr < 0 ? operationHr : activationHr;
+            if (activateResult >= 0) {
+                activatedInterface = activationInterface;
+            }
+        } catch (Exception ex) {
+            activateResult = Marshal.GetHRForException(ex);
+        } finally {
+            completedEvent.Set();
+        }
+        return 0;
+    }
+
+    public IAudioClient WaitForClient(int timeoutMilliseconds) {
+        if (!completedEvent.WaitOne(timeoutMilliseconds)) {
+            throw new TimeoutException("ActivateAudioInterfaceAsync timed out");
+        }
+        Check(activateResult, "GetActivateResult");
+        if (activatedInterface == null) {
+            throw new InvalidOperationException("ActivateAudioInterfaceAsync returned no audio client");
+        }
+        IAudioClient audioClient = (IAudioClient)activatedInterface;
+        activatedInterface = null;
+        return audioClient;
+    }
+
+    public void Dispose() {
+        completedEvent.Dispose();
+    }
+
+    private static void Check(int hr, string operation) {
+        if (hr < 0) {
+            Marshal.ThrowExceptionForHR(hr);
+        }
+    }
+}
+
+internal static class Program {
+    private const ushort VT_BLOB = 0x0041;
+    private const string VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK = "VAD\\Process_Loopback";
+    private const int ActivateAudioInterfaceTimeoutMilliseconds = 10000;
+
+    [DllImport("Mmdevapi.dll", ExactSpelling = true, CharSet = CharSet.Unicode)]
+    private static extern int ActivateAudioInterfaceAsync(
+        [MarshalAs(UnmanagedType.LPWStr)] string deviceInterfacePath,
+        ref Guid riid,
+        ref PROPVARIANT activationParams,
+        IActivateAudioInterfaceCompletionHandler completionHandler,
+        out IActivateAudioInterfaceAsyncOperation activationOperation
+    );
+
+    [MTAThread]
+    private static int Main(string[] args) {
+        try {
+            if (args.Length == 0) {
+                throw new InvalidOperationException("expected --list-applications or --capture-audio");
+            }
+
+            if (string.Equals(args[0], "--list-applications", StringComparison.OrdinalIgnoreCase)) {
+                WriteApplicationsJson();
+                return 0;
+            }
+
+            if (string.Equals(args[0], "--capture-audio", StringComparison.OrdinalIgnoreCase)) {
+                int processId = 0;
+                int sampleRateHz = 16000;
+                int channels = 1;
+                for (int index = 1; index < args.Length; index += 2) {
+                    if (index + 1 >= args.Length) {
+                        throw new InvalidOperationException("missing argument value");
+                    }
+                    string option = args[index];
+                    string value = args[index + 1];
+                    if (string.Equals(option, "--process-id", StringComparison.OrdinalIgnoreCase)) {
+                        processId = int.Parse(value);
+                    } else if (string.Equals(option, "--sample-rate-hz", StringComparison.OrdinalIgnoreCase)) {
+                        sampleRateHz = int.Parse(value);
+                    } else if (string.Equals(option, "--channels", StringComparison.OrdinalIgnoreCase)) {
+                        channels = int.Parse(value);
+                    } else {
+                        throw new InvalidOperationException("unsupported option: " + option);
+                    }
+                }
+                if (processId <= 0) {
+                    throw new InvalidOperationException("--capture-audio requires --process-id");
+                }
+                CaptureLoopback(processId, sampleRateHz, channels);
+                return 0;
+            }
+
+            throw new InvalidOperationException("unsupported command: " + args[0]);
+        } catch (Exception ex) {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+
+    private static void WriteApplicationsJson() {
+        var applications = new List<ApplicationInfo>();
+        foreach (Process process in Process.GetProcesses()) {
+            try {
+                string processName = process.ProcessName;
+                string executablePath = null;
+                string windowTitle = null;
+                try {
+                    executablePath = process.MainModule != null ? process.MainModule.FileName : null;
+                } catch {
+                    executablePath = null;
+                }
+                try {
+                    windowTitle = process.MainWindowTitle;
+                } catch {
+                    windowTitle = null;
+                }
+                if (string.IsNullOrWhiteSpace(processName) && string.IsNullOrWhiteSpace(windowTitle)) {
+                    continue;
+                }
+                applications.Add(new ApplicationInfo {
+                    ProcessId = process.Id,
+                    ApplicationName = processName,
+                    BundleIdentifier = string.IsNullOrWhiteSpace(executablePath) ? null : executablePath,
+                    WindowTitle = string.IsNullOrWhiteSpace(windowTitle) ? null : windowTitle,
+                });
+            } catch {
+            } finally {
+                process.Dispose();
+            }
+        }
+        applications.Sort((left, right) => {
+            int byName = string.Compare(left.ApplicationName, right.ApplicationName, StringComparison.OrdinalIgnoreCase);
+            if (byName != 0) {
+                return byName;
+            }
+            int byWindowTitle = string.Compare(left.WindowTitle, right.WindowTitle, StringComparison.OrdinalIgnoreCase);
+            if (byWindowTitle != 0) {
+                return byWindowTitle;
+            }
+            return left.ProcessId.CompareTo(right.ProcessId);
+        });
+        var serializer = new DataContractJsonSerializer(typeof(List<ApplicationInfo>));
+        serializer.WriteObject(Console.OpenStandardOutput(), applications);
+    }
+
+    private static void CaptureLoopback(int processId, int sampleRateHz, int channels) {
+        Process targetProcess = Process.GetProcessById(processId);
+        IAudioClient audioClient = null;
+        IAudioCaptureClient captureClient = null;
+        IntPtr formatPtr = IntPtr.Zero;
+        try {
+            audioClient = ActivateProcessLoopbackAudioClient(processId);
+            var format = new WAVEFORMATEX();
+            format.wFormatTag = 1;
+            format.nChannels = (ushort)Math.Max(1, channels);
+            format.nSamplesPerSec = (uint)Math.Max(1, sampleRateHz);
+            format.wBitsPerSample = 16;
+            format.nBlockAlign = (ushort)(format.nChannels * (format.wBitsPerSample / 8));
+            format.nAvgBytesPerSec = format.nSamplesPerSec * format.nBlockAlign;
+            format.cbSize = 0;
+            formatPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(WAVEFORMATEX)));
+            Marshal.StructureToPtr(format, formatPtr, false);
+
+            Check(
+                audioClient.Initialize(
+                    AudioClientShareMode.Shared,
+                    AudioClientStreamFlags.Loopback | AudioClientStreamFlags.EventCallback,
+                    0,
+                    0,
+                    formatPtr,
+                    IntPtr.Zero
+                ),
+                "Initialize"
+            );
+
+            Guid captureClientGuid = typeof(IAudioCaptureClient).GUID;
+            Check(audioClient.GetService(ref captureClientGuid, out captureClient), "GetService");
+
+            using (var readyEvent = new AutoResetEvent(false)) {
+                Check(audioClient.SetEventHandle(readyEvent.SafeWaitHandle.DangerousGetHandle()), "SetEventHandle");
+                Check(audioClient.Start(), "Start");
+                try {
+                    Stream stdout = Console.OpenStandardOutput();
+                    while (true) {
+                        targetProcess.Refresh();
+                        if (targetProcess.HasExited) {
+                            return;
+                        }
+                        readyEvent.WaitOne(250);
+                        uint packetSize;
+                        while (captureClient.GetNextPacketSize(out packetSize) == 0 && packetSize > 0) {
+                            IntPtr data;
+                            uint frameCount;
+                            AudioClientBufferFlags flags;
+                            ulong devicePosition;
+                            ulong qpcPosition;
+                            Check(
+                                captureClient.GetBuffer(
+                                    out data,
+                                    out frameCount,
+                                    out flags,
+                                    out devicePosition,
+                                    out qpcPosition
+                                ),
+                                "GetBuffer"
+                            );
+                            try {
+                                int byteCount = checked((int)(frameCount * format.nBlockAlign));
+                                byte[] buffer = new byte[byteCount];
+                                if ((flags & AudioClientBufferFlags.Silent) != AudioClientBufferFlags.Silent && byteCount > 0) {
+                                    Marshal.Copy(data, buffer, 0, byteCount);
+                                }
+                                stdout.Write(buffer, 0, buffer.Length);
+                            } finally {
+                                Check(captureClient.ReleaseBuffer(frameCount), "ReleaseBuffer");
+                            }
+                        }
+                    }
+                } finally {
+                    audioClient.Stop();
+                }
+            }
+        } finally {
+            if (formatPtr != IntPtr.Zero) {
+                Marshal.FreeHGlobal(formatPtr);
+            }
+            if (captureClient != null && Marshal.IsComObject(captureClient)) {
+                Marshal.ReleaseComObject(captureClient);
+            }
+            if (audioClient != null && Marshal.IsComObject(audioClient)) {
+                Marshal.ReleaseComObject(audioClient);
+            }
+            targetProcess.Dispose();
+        }
+    }
+
+    private static IAudioClient ActivateProcessLoopbackAudioClient(int processId) {
+        var activationParams = new AUDIOCLIENT_ACTIVATION_PARAMS {
+            ActivationType = AUDIOCLIENT_ACTIVATION_TYPE.AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK,
+            ProcessLoopbackParams = new AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS {
+                TargetProcessId = (uint)processId,
+                ProcessLoopbackMode = PROCESS_LOOPBACK_MODE.PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE,
+            },
+        };
+        IntPtr activationParamsPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(AUDIOCLIENT_ACTIVATION_PARAMS)));
+        Marshal.StructureToPtr(activationParams, activationParamsPtr, false);
+        var propVariant = new PROPVARIANT {
+            vt = VT_BLOB,
+            blob = new BLOB {
+                cbSize = (uint)Marshal.SizeOf(typeof(AUDIOCLIENT_ACTIVATION_PARAMS)),
+                pBlobData = activationParamsPtr,
+            },
+        };
+        Guid audioClientGuid = typeof(IAudioClient).GUID;
+        using (var completionHandler = new ActivateAudioInterfaceCompletionHandler()) {
+            IActivateAudioInterfaceAsyncOperation activationOperation = null;
+            try {
+                Check(
+                    ActivateAudioInterfaceAsync(
+                        VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK,
+                        ref audioClientGuid,
+                        ref propVariant,
+                        completionHandler,
+                        out activationOperation
+                    ),
+                    "ActivateAudioInterfaceAsync"
+                );
+                return completionHandler.WaitForClient(ActivateAudioInterfaceTimeoutMilliseconds);
+            } finally {
+                if (activationOperation != null && Marshal.IsComObject(activationOperation)) {
+                    Marshal.ReleaseComObject(activationOperation);
+                }
+                Marshal.FreeHGlobal(activationParamsPtr);
+            }
+        }
+    }
+
+    private static void Check(int hr, string operation) {
+        if (hr < 0) {
+            Marshal.ThrowExceptionForHR(hr);
+        }
+    }
+}
+"""
+_APPLICATION_AUDIO_HELPER_HASH = hashlib.sha256(
+    _APPLICATION_AUDIO_HELPER_SOURCE.encode("utf-8")
+).hexdigest()[:12]
+_APPLICATION_AUDIO_HELPER_SOURCE_PATH = (
+    _APPLICATION_AUDIO_HELPER_DIR / f"windows-application-audio-{_APPLICATION_AUDIO_HELPER_HASH}.cs"
+)
+_APPLICATION_AUDIO_HELPER_BINARY_PATH = (
+    _APPLICATION_AUDIO_HELPER_DIR / f"windows-application-audio-{_APPLICATION_AUDIO_HELPER_HASH}.exe"
+)
+
+
+@dataclass(frozen=True)
+class _WindowsApplicationInfo:
+    process_id: int
+    application_name: str
+    bundle_identifier: str | None
+    window_title: str | None
+
+
+class WindowsApplicationAudioInput(AudioInput):
+    def __init__(
+        self,
+        target: str,
+        sample_rate_hz: int = 16_000,
+        channels: int = 1,
+        sample_width_bytes: int = 2,
+        block_duration_ms: float = 40.0,
+        speech_threshold: float = 0.02,
+        pre_speech_ms: float = 200.0,
+        speech_hold_ms: float = 320.0,
+        silence_threshold_ms: float = 650.0,
+        min_utterance_ms: float = 250.0,
+        max_utterance_ms: float = 15_000.0,
+        timeout_seconds: float = 10.0,
+        adaptive_vad_enabled: bool = True,
+        speech_start_events_enabled: bool = True,
+    ) -> None:
+        self.target = target
+        self.sample_rate_hz = sample_rate_hz
+        self.channels = channels
+        self.sample_width_bytes = sample_width_bytes
+        self.block_duration_ms = block_duration_ms
+        self.frames_per_block = max(1, int(sample_rate_hz * block_duration_ms / 1000.0))
+        self.bytes_per_block = (
+            self.frames_per_block * self.channels * self.sample_width_bytes
+        )
+        self.timeout_seconds = timeout_seconds
+        self.adaptive_vad_enabled = adaptive_vad_enabled
+        self.speech_start_events_enabled = speech_start_events_enabled
+        self._on_speech_start: Callable[[], Awaitable[None] | None] | None = None
+        self._background_tasks: set[asyncio.Future[object]] = set()
+        self._accumulator = UtteranceAccumulator(
+            sample_rate_hz=sample_rate_hz,
+            channels=channels,
+            sample_width_bytes=sample_width_bytes,
+            speech_threshold=speech_threshold,
+            pre_speech_ms=pre_speech_ms,
+            speech_hold_ms=speech_hold_ms,
+            min_utterance_ms=min_utterance_ms,
+            max_utterance_ms=max_utterance_ms,
+            segment_source="application_audio",
+            segment_source_label=None,
+            turn_detector=FixedSilenceTurnDetector(silence_threshold_ms=silence_threshold_ms),
+            speech_detector=(
+                AdaptiveEnergySpeechDetector(speech_threshold=speech_threshold)
+                if adaptive_vad_enabled
+                else None
+            ),
+            on_speech_start=self._emit_speech_start,
+        )
+        self._selected_application: _WindowsApplicationInfo | None = None
+        self._process: asyncio.subprocess.Process | None = None
+        self._stderr_task: asyncio.Task[None] | None = None
+        self._stderr_tail: deque[str] = deque(maxlen=8)
+        self._helper_path: Path | None = None
+        self._helper_lock = asyncio.Lock()
+        self._closed = False
+
+    async def start(self) -> str:
+        await self._ensure_process()
+        return self.selected_application_label
+
+    def set_speech_start_handler(
+        self,
+        handler: Callable[[], Awaitable[None] | None] | None,
+    ) -> None:
+        if not self.speech_start_events_enabled:
+            self._on_speech_start = None
+            return
+        self._on_speech_start = handler
+
+    @property
+    def selected_application_label(self) -> str:
+        if self._selected_application is None:
+            return f"application audio target {self.target!r}"
+        label = (
+            f"application audio {self._selected_application.application_name} "
+            f"(pid={self._selected_application.process_id})"
+        )
+        if self._selected_application.window_title:
+            return f"{label} {self._selected_application.window_title!r}"
+        return label
+
+    async def read(self) -> AudioSegment | None:
+        if self._closed:
+            return None
+        process = await self._ensure_process()
+        while not self._closed:
+            chunk = await self._read_chunk(process)
+            if not chunk:
+                return self._flush_after_process_end()
+            segment = self._accumulator.add_chunk(chunk)
+            if segment is not None:
+                return segment
+        return self._accumulator.flush()
+
+    async def close(self) -> None:
+        self._closed = True
+        process = self._process
+        self._process = None
+        if process is not None:
+            await terminate_process(process)
+        stderr_task = self._stderr_task
+        self._stderr_task = None
+        if stderr_task is not None:
+            stderr_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stderr_task
+        if self._background_tasks:
+            await asyncio.gather(*tuple(self._background_tasks), return_exceptions=True)
+        if self._selected_application is not None:
+            log_event(
+                logger,
+                "application_audio_stream_closed",
+                application_name=self._selected_application.application_name,
+                executable_path=self._selected_application.bundle_identifier,
+                process_id=self._selected_application.process_id,
+                window_title=self._selected_application.window_title,
+            )
+
+    async def _ensure_process(self) -> asyncio.subprocess.Process:
+        process = self._process
+        if process is not None:
+            return process
+        helper_path = await self._ensure_helper()
+        selected_application = await self._resolve_target_application(helper_path)
+        try:
+            process = await asyncio.create_subprocess_exec(
+                str(helper_path),
+                "--capture-audio",
+                "--process-id",
+                str(selected_application.process_id),
+                "--sample-rate-hz",
+                str(self.sample_rate_hz),
+                "--channels",
+                str(self.channels),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError("Windows application audio helper is unavailable") from exc
+        self._selected_application = selected_application
+        self._accumulator.segment_source_label = selected_application.application_name
+        self._process = process
+        self._stderr_tail.clear()
+        self._stderr_task = asyncio.create_task(
+            self._drain_stderr(process),
+            name="vocalive-windows-application-audio-stderr",
+        )
+        log_event(
+            logger,
+            "application_audio_stream_started",
+            application_name=selected_application.application_name,
+            executable_path=selected_application.bundle_identifier,
+            process_id=selected_application.process_id,
+            window_title=selected_application.window_title,
+            sample_rate_hz=self.sample_rate_hz,
+            channels=self.channels,
+            speech_threshold=self._accumulator.speech_threshold,
+            adaptive_vad=self.adaptive_vad_enabled,
+            backend="windows_process_loopback",
+        )
+        return process
+
+    async def _read_chunk(self, process: asyncio.subprocess.Process) -> bytes:
+        stdout = process.stdout
+        if stdout is None:
+            raise RuntimeError("Windows application audio capture stdout is unavailable")
+        try:
+            return await stdout.readexactly(self.bytes_per_block)
+        except asyncio.IncompleteReadError as exc:
+            if exc.partial:
+                return bytes(exc.partial)
+            await process.wait()
+            self._raise_if_process_failed(process)
+            return b""
+
+    def _flush_after_process_end(self) -> AudioSegment | None:
+        self._closed = True
+        return self._accumulator.flush()
+
+    async def _resolve_target_application(
+        self,
+        helper_path: Path,
+    ) -> _WindowsApplicationInfo:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                str(helper_path),
+                "--list-applications",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await communicate_with_cancellation(
+                process=process,
+                cancellation=None,
+                timeout_seconds=self.timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError("Windows application audio helper is unavailable") from exc
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError("Windows application audio app lookup timed out") from exc
+        if process.returncode != 0:
+            detail = stderr.decode("utf-8", errors="replace").strip() if stderr else ""
+            suffix = f": {detail}" if detail else ""
+            raise RuntimeError(f"Windows application audio app lookup failed{suffix}")
+        try:
+            raw_applications = json.loads(stdout.decode("utf-8") or "[]")
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Windows application audio app lookup returned invalid JSON") from exc
+        applications = tuple(
+            _coerce_application_info(entry)
+            for entry in raw_applications
+            if isinstance(entry, dict)
+        )
+        selected_application = _select_application(applications, self.target)
+        if selected_application is None:
+            raise RuntimeError(
+                f"No running Windows application matched VOCALIVE_APP_AUDIO_TARGET={self.target!r}"
+            )
+        return selected_application
+
+    async def _ensure_helper(self) -> Path:
+        cached_path = self._helper_path
+        if cached_path is not None and cached_path.exists():
+            return cached_path
+        async with self._helper_lock:
+            cached_path = self._helper_path
+            if cached_path is not None and cached_path.exists():
+                return cached_path
+            if _APPLICATION_AUDIO_HELPER_BINARY_PATH.exists():
+                self._helper_path = _APPLICATION_AUDIO_HELPER_BINARY_PATH
+                return _APPLICATION_AUDIO_HELPER_BINARY_PATH
+            helper_path = await ensure_csharp_helper(
+                source=_APPLICATION_AUDIO_HELPER_SOURCE,
+                source_path=_APPLICATION_AUDIO_HELPER_SOURCE_PATH,
+                output_path=_APPLICATION_AUDIO_HELPER_BINARY_PATH,
+                references=("System.Runtime.Serialization.dll",),
+                timeout_seconds=self.timeout_seconds,
+                build_timeout_floor_seconds=_APPLICATION_AUDIO_HELPER_BUILD_TIMEOUT_FLOOR_SECONDS,
+                cancellation=None,
+                unavailable_message="csc.exe is unavailable for Windows application audio capture",
+                timeout_message="Windows application audio helper build timed out",
+                failure_message="Windows application audio helper build failed",
+            )
+            self._helper_path = helper_path
+            return helper_path
+
+    async def _drain_stderr(self, process: asyncio.subprocess.Process) -> None:
+        stderr = process.stderr
+        if stderr is None:
+            return
+        while True:
+            line = await stderr.readline()
+            if not line:
+                return
+            normalized_line = line.decode("utf-8", errors="replace").strip()
+            if normalized_line:
+                self._stderr_tail.append(normalized_line)
+
+    def _raise_if_process_failed(self, process: asyncio.subprocess.Process) -> None:
+        if process.returncode in {None, 0}:
+            return
+        detail = "; ".join(self._stderr_tail)
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(f"Windows application audio capture failed{suffix}")
+
+    def _emit_speech_start(self) -> None:
+        handler = self._on_speech_start
+        if handler is None:
+            return
+        result = handler()
+        if not inspect.isawaitable(result):
+            return
+        task = asyncio.ensure_future(result)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._finalize_background_task)
+
+    def _finalize_background_task(self, task: asyncio.Future[object]) -> None:
+        self._background_tasks.discard(task)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            log_event(
+                logger,
+                "application_audio_speech_start_handler_failed",
+                error=str(exc),
+            )
+
+
+def _coerce_application_info(raw_application: dict[str, object]) -> _WindowsApplicationInfo:
+    application_name = str(raw_application.get("applicationName") or "").strip()
+    bundle_identifier = str(raw_application.get("bundleIdentifier") or "").strip() or None
+    window_title = str(raw_application.get("windowTitle") or "").strip() or None
+    return _WindowsApplicationInfo(
+        process_id=int(raw_application["processId"]),
+        application_name=application_name,
+        bundle_identifier=bundle_identifier,
+        window_title=window_title,
+    )
+
+
+def _select_application(
+    applications: tuple[_WindowsApplicationInfo, ...],
+    target: str,
+) -> _WindowsApplicationInfo | None:
+    normalized_target = _normalize_application_match_text(target)
+    if not normalized_target:
+        return None
+    matchers = (
+        lambda application: _normalize_application_match_text(application.application_name),
+        lambda application: _normalize_application_match_text(application.bundle_identifier or ""),
+        lambda application: _normalize_application_match_text(application.window_title or ""),
+    )
+    for matcher in matchers:
+        for application in applications:
+            if matcher(application) == normalized_target:
+                return application
+    for matcher in matchers:
+        for application in applications:
+            normalized_value = matcher(application)
+            if normalized_value and normalized_target in normalized_value:
+                return application
+    return None
+
+
+def _normalize_application_match_text(value: str) -> str:
+    return " ".join(value.lower().replace("_", " ").split())

--- a/src/vocalive/main.py
+++ b/src/vocalive/main.py
@@ -4,7 +4,6 @@ import asyncio
 import sys
 
 from vocalive.audio.input import AudioInput, CombinedAudioInput, MicrophoneAudioInput
-from vocalive.audio.macos_application import MacOSApplicationAudioInput
 from vocalive.audio.output import MemoryAudioOutput, SpeakerAudioOutput, parse_playback_command
 from vocalive.config.settings import (
     AppSettings,
@@ -17,13 +16,15 @@ from vocalive.llm.gemini import GeminiLanguageModel
 from vocalive.models import AudioSegment
 from vocalive.pipeline.events import ConversationEventSink
 from vocalive.pipeline.orchestrator import ConversationOrchestrator
-from vocalive.screen.macos import MacOSWindowScreenCapture
 from vocalive.stt.mock import MockSpeechToTextEngine
 from vocalive.stt.moonshine import MoonshineSpeechToTextEngine
 from vocalive.tts.mock import MockTextToSpeechEngine
 from vocalive.tts.aivis import AivisSpeechTextToSpeechEngine
 from vocalive.ui.overlay import OverlayServer
-from vocalive.util.logging import configure_logging
+from vocalive.util.logging import configure_logging, get_logger, log_event
+
+
+logger = get_logger(__name__)
 
 
 async def run_cli() -> int:
@@ -108,11 +109,12 @@ def build_orchestrator(
             raise ValueError(
                 "screen capture input currently requires VOCALIVE_SCREEN_WINDOW_NAME"
             )
-        if sys.platform != "darwin":
+        screen_capture_engine_class = _screen_capture_engine_class_for_platform(sys.platform)
+        if screen_capture_engine_class is None:
             raise ValueError(
-                "screen capture input currently supports macOS only"
+                "screen capture input currently supports macOS and Windows only"
             )
-        screen_capture_engine = MacOSWindowScreenCapture(
+        screen_capture_engine = screen_capture_engine_class(
             window_name=settings.screen_capture.window_name,
             timeout_seconds=settings.screen_capture.timeout_seconds,
             resize_max_edge_px=settings.screen_capture.resize_max_edge_px,
@@ -151,12 +153,19 @@ def build_audio_input(settings: AppSettings) -> AudioInput | None:
             raise ValueError(
                 "application audio input currently requires VOCALIVE_APP_AUDIO_TARGET"
             )
-        if sys.platform != "darwin":
+        application_audio_input_class = _application_audio_input_class_for_platform(sys.platform)
+        if application_audio_input_class is None:
             raise ValueError(
-                "application audio input currently supports macOS only"
+                "application audio input currently supports macOS and Windows only"
+            )
+        if sys.platform == "win32":
+            log_event(
+                logger,
+                "windows_application_audio_loopback_enabled",
+                output_provider=settings.output.provider,
             )
         live_inputs.append(
-            MacOSApplicationAudioInput(
+            application_audio_input_class(
                 target=settings.application_audio.target,
                 sample_rate_hz=settings.application_audio.sample_rate_hz,
                 channels=settings.application_audio.channels,
@@ -231,6 +240,32 @@ def _uses_live_audio_input(settings: AppSettings) -> bool:
         settings.input.provider == InputProvider.MICROPHONE
         or settings.application_audio.enabled
     )
+
+
+def _application_audio_input_class_for_platform(
+    platform: str,
+) -> type[AudioInput] | None:
+    if platform == "darwin":
+        from vocalive.audio.macos_application import MacOSApplicationAudioInput
+
+        return MacOSApplicationAudioInput
+    if platform == "win32":
+        from vocalive.audio.windows_application import WindowsApplicationAudioInput
+
+        return WindowsApplicationAudioInput
+    return None
+
+
+def _screen_capture_engine_class_for_platform(platform: str):
+    if platform == "darwin":
+        from vocalive.screen.macos import MacOSWindowScreenCapture
+
+        return MacOSWindowScreenCapture
+    if platform == "win32":
+        from vocalive.screen.windows import WindowsWindowScreenCapture
+
+        return WindowsWindowScreenCapture
+    return None
 
 
 def main() -> int:

--- a/src/vocalive/screen/__init__.py
+++ b/src/vocalive/screen/__init__.py
@@ -1,7 +1,9 @@
 from .base import ScreenCaptureEngine
 from .macos import MacOSWindowScreenCapture
+from .windows import WindowsWindowScreenCapture
 
 __all__ = [
     "MacOSWindowScreenCapture",
     "ScreenCaptureEngine",
+    "WindowsWindowScreenCapture",
 ]

--- a/src/vocalive/screen/windows.py
+++ b/src/vocalive/screen/windows.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from vocalive.models import ConversationInlineDataPart, TurnContext
+from vocalive.pipeline.interruption import CancellationToken
+from vocalive.screen.base import ScreenCaptureEngine
+from vocalive.util.windows_csharp import communicate_with_cancellation, ensure_csharp_helper
+
+
+_WINDOW_CAPTURE_HELPER_BUILD_TIMEOUT_FLOOR_SECONDS = 10.0
+_WINDOW_CAPTURE_HELPER_DIR = Path(tempfile.gettempdir()) / "vocalive-screen-capture"
+_WINDOW_CAPTURE_HELPER_SOURCE = r"""
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+[DataContract]
+internal sealed class WindowInfo {
+    [DataMember(Name = "windowID")]
+    public long WindowId { get; set; }
+
+    [DataMember(Name = "ownerName")]
+    public string OwnerName { get; set; }
+
+    [DataMember(Name = "windowName")]
+    public string WindowName { get; set; }
+
+    [DataMember(Name = "layer")]
+    public int Layer { get; set; }
+}
+
+internal static class NativeMethods {
+    internal delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct RECT {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [DllImport("user32.dll")]
+    internal static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    internal static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    internal static extern int GetWindowTextLength(IntPtr hWnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    internal static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int maxCount);
+
+    [DllImport("user32.dll")]
+    internal static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+    [DllImport("user32.dll")]
+    internal static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+
+    [DllImport("user32.dll")]
+    internal static extern bool PrintWindow(IntPtr hWnd, IntPtr hdcBlt, uint flags);
+
+    [DllImport("user32.dll")]
+    internal static extern IntPtr GetWindowDC(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    internal static extern int ReleaseDC(IntPtr hWnd, IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    internal static extern bool BitBlt(
+        IntPtr hdcDest,
+        int xDest,
+        int yDest,
+        int width,
+        int height,
+        IntPtr hdcSrc,
+        int xSrc,
+        int ySrc,
+        int rop
+    );
+}
+
+internal static class Program {
+    private const int SRCCOPY = 0x00CC0020;
+    private const uint PW_RENDERFULLCONTENT = 0x00000002;
+
+    private static int Main(string[] args) {
+        try {
+            if (args.Length == 0) {
+                throw new InvalidOperationException("expected --list-windows or --capture-window");
+            }
+
+            if (string.Equals(args[0], "--list-windows", StringComparison.OrdinalIgnoreCase)) {
+                WriteWindowsJson();
+                return 0;
+            }
+
+            if (string.Equals(args[0], "--capture-window", StringComparison.OrdinalIgnoreCase)) {
+                long windowId = 0;
+                string outputPath = null;
+                int maxEdgePx = 0;
+                bool hasMaxEdge = false;
+                for (int index = 1; index < args.Length; index += 2) {
+                    if (index + 1 >= args.Length) {
+                        throw new InvalidOperationException("missing argument value");
+                    }
+                    string option = args[index];
+                    string value = args[index + 1];
+                    if (string.Equals(option, "--window-id", StringComparison.OrdinalIgnoreCase)) {
+                        windowId = long.Parse(value);
+                    } else if (string.Equals(option, "--output-path", StringComparison.OrdinalIgnoreCase)) {
+                        outputPath = value;
+                    } else if (string.Equals(option, "--max-edge-px", StringComparison.OrdinalIgnoreCase)) {
+                        maxEdgePx = int.Parse(value);
+                        hasMaxEdge = true;
+                    } else {
+                        throw new InvalidOperationException("unsupported option: " + option);
+                    }
+                }
+                if (windowId == 0 || string.IsNullOrWhiteSpace(outputPath)) {
+                    throw new InvalidOperationException("--capture-window requires --window-id and --output-path");
+                }
+                CaptureWindow(new IntPtr(windowId), outputPath, hasMaxEdge ? (int?)maxEdgePx : null);
+                return 0;
+            }
+
+            throw new InvalidOperationException("unsupported command: " + args[0]);
+        } catch (Exception ex) {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+
+    private static void WriteWindowsJson() {
+        var windows = new List<WindowInfo>();
+        NativeMethods.EnumWindows((hWnd, _) => {
+            if (!NativeMethods.IsWindowVisible(hWnd)) {
+                return true;
+            }
+            string windowTitle = ReadWindowText(hWnd);
+            uint processId;
+            NativeMethods.GetWindowThreadProcessId(hWnd, out processId);
+            string ownerName = string.Empty;
+            try {
+                ownerName = Process.GetProcessById((int)processId).ProcessName;
+            } catch {
+                ownerName = string.Empty;
+            }
+            if (string.IsNullOrWhiteSpace(windowTitle) && string.IsNullOrWhiteSpace(ownerName)) {
+                return true;
+            }
+            windows.Add(new WindowInfo {
+                WindowId = hWnd.ToInt64(),
+                OwnerName = ownerName ?? string.Empty,
+                WindowName = string.IsNullOrWhiteSpace(windowTitle) ? null : windowTitle,
+                Layer = 0,
+            });
+            return true;
+        }, IntPtr.Zero);
+
+        var serializer = new DataContractJsonSerializer(typeof(List<WindowInfo>));
+        serializer.WriteObject(Console.OpenStandardOutput(), windows);
+    }
+
+    private static string ReadWindowText(IntPtr hWnd) {
+        int length = NativeMethods.GetWindowTextLength(hWnd);
+        if (length <= 0) {
+            return string.Empty;
+        }
+        var builder = new StringBuilder(length + 1);
+        NativeMethods.GetWindowText(hWnd, builder, builder.Capacity);
+        return builder.ToString();
+    }
+
+    private static void CaptureWindow(IntPtr hWnd, string outputPath, int? maxEdgePx) {
+        NativeMethods.RECT rect;
+        if (!NativeMethods.GetWindowRect(hWnd, out rect)) {
+            throw new InvalidOperationException("GetWindowRect failed");
+        }
+        int width = Math.Max(1, rect.Right - rect.Left);
+        int height = Math.Max(1, rect.Bottom - rect.Top);
+
+        using (var bitmap = new Bitmap(width, height))
+        using (var graphics = Graphics.FromImage(bitmap)) {
+            graphics.Clear(Color.Black);
+            bool rendered = TryPrintWindow(hWnd, graphics, PW_RENDERFULLCONTENT)
+                || TryPrintWindow(hWnd, graphics, 0);
+            if (!rendered) {
+                IntPtr sourceDc = NativeMethods.GetWindowDC(hWnd);
+                if (sourceDc == IntPtr.Zero) {
+                    throw new InvalidOperationException("GetWindowDC failed");
+                }
+                IntPtr targetDc = graphics.GetHdc();
+                try {
+                    if (!NativeMethods.BitBlt(targetDc, 0, 0, width, height, sourceDc, 0, 0, SRCCOPY)) {
+                        throw new InvalidOperationException("BitBlt failed");
+                    }
+                } finally {
+                    graphics.ReleaseHdc(targetDc);
+                    NativeMethods.ReleaseDC(hWnd, sourceDc);
+                }
+            }
+
+            using (var outputBitmap = ResizeIfNeeded(bitmap, maxEdgePx)) {
+                outputBitmap.Save(outputPath, ImageFormat.Png);
+            }
+        }
+    }
+
+    private static bool TryPrintWindow(IntPtr hWnd, Graphics graphics, uint flags) {
+        IntPtr targetDc = graphics.GetHdc();
+        try {
+            return NativeMethods.PrintWindow(hWnd, targetDc, flags);
+        } finally {
+            graphics.ReleaseHdc(targetDc);
+        }
+    }
+
+    private static Bitmap ResizeIfNeeded(Bitmap bitmap, int? maxEdgePx) {
+        if (!maxEdgePx.HasValue) {
+            return (Bitmap)bitmap.Clone();
+        }
+        int maxEdge = maxEdgePx.Value;
+        if (maxEdge <= 0 || (bitmap.Width <= maxEdge && bitmap.Height <= maxEdge)) {
+            return (Bitmap)bitmap.Clone();
+        }
+        double scale = Math.Min((double)maxEdge / bitmap.Width, (double)maxEdge / bitmap.Height);
+        int resizedWidth = Math.Max(1, (int)Math.Round(bitmap.Width * scale));
+        int resizedHeight = Math.Max(1, (int)Math.Round(bitmap.Height * scale));
+        var resized = new Bitmap(resizedWidth, resizedHeight);
+        using (var graphics = Graphics.FromImage(resized)) {
+            graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+            graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
+            graphics.SmoothingMode = SmoothingMode.HighQuality;
+            graphics.DrawImage(bitmap, 0, 0, resizedWidth, resizedHeight);
+        }
+        return resized;
+    }
+}
+"""
+_WINDOW_CAPTURE_HELPER_HASH = hashlib.sha256(
+    _WINDOW_CAPTURE_HELPER_SOURCE.encode("utf-8")
+).hexdigest()[:12]
+_WINDOW_CAPTURE_HELPER_SOURCE_PATH = (
+    _WINDOW_CAPTURE_HELPER_DIR / f"windows-window-capture-{_WINDOW_CAPTURE_HELPER_HASH}.cs"
+)
+_WINDOW_CAPTURE_HELPER_BINARY_PATH = (
+    _WINDOW_CAPTURE_HELPER_DIR / f"windows-window-capture-{_WINDOW_CAPTURE_HELPER_HASH}.exe"
+)
+
+
+@dataclass(frozen=True)
+class _WindowsWindowInfo:
+    window_id: int
+    owner_name: str
+    window_name: str | None
+    layer: int
+
+
+class WindowsWindowScreenCapture(ScreenCaptureEngine):
+    name = "windows-window-capture"
+
+    def __init__(
+        self,
+        window_name: str,
+        timeout_seconds: float = 5.0,
+        resize_max_edge_px: int | None = 1280,
+    ) -> None:
+        self.window_name = window_name
+        self.timeout_seconds = timeout_seconds
+        self.resize_max_edge_px = resize_max_edge_px
+        self._cached_window_id: int | None = None
+        self._window_capture_helper_path: Path | None = None
+        self._window_capture_helper_lock = asyncio.Lock()
+
+    async def capture(
+        self,
+        context: TurnContext,
+        cancellation: CancellationToken | None = None,
+    ) -> ConversationInlineDataPart:
+        del context
+        if cancellation is not None:
+            cancellation.raise_if_cancelled()
+        cached_window_id = self._cached_window_id
+        if cached_window_id is not None:
+            try:
+                return await self._capture_window(
+                    window_id=cached_window_id,
+                    cancellation=cancellation,
+                )
+            except RuntimeError:
+                self._cached_window_id = None
+
+        window_id = await self._resolve_window_id(cancellation=cancellation)
+        self._cached_window_id = window_id
+        return await self._capture_window(
+            window_id=window_id,
+            cancellation=cancellation,
+        )
+
+    async def _resolve_window_id(
+        self,
+        cancellation: CancellationToken | None = None,
+    ) -> int:
+        helper_path = await self._ensure_window_capture_helper(cancellation=cancellation)
+        try:
+            process = await asyncio.create_subprocess_exec(
+                str(helper_path),
+                "--list-windows",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await communicate_with_cancellation(
+                process=process,
+                cancellation=cancellation,
+                timeout_seconds=self.timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError("Windows window capture helper is unavailable") from exc
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError("Windows window lookup timed out") from exc
+        if process.returncode != 0:
+            stderr_text = stderr.decode("utf-8", errors="replace").strip() if stderr else ""
+            detail = f": {stderr_text}" if stderr_text else ""
+            raise RuntimeError(f"Windows window lookup failed{detail}")
+        try:
+            raw_windows = json.loads(stdout.decode("utf-8") or "[]")
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Windows window lookup returned invalid JSON") from exc
+        windows = tuple(_coerce_window_info(entry) for entry in raw_windows if isinstance(entry, dict))
+        selected_window = _select_window(windows, self.window_name)
+        if selected_window is None:
+            raise RuntimeError(
+                f"No on-screen window matched VOCALIVE_SCREEN_WINDOW_NAME={self.window_name!r}"
+            )
+        return selected_window.window_id
+
+    async def _ensure_window_capture_helper(
+        self,
+        cancellation: CancellationToken | None = None,
+    ) -> Path:
+        cached_path = self._window_capture_helper_path
+        if cached_path is not None and cached_path.exists():
+            return cached_path
+
+        async with self._window_capture_helper_lock:
+            cached_path = self._window_capture_helper_path
+            if cached_path is not None and cached_path.exists():
+                return cached_path
+            if _WINDOW_CAPTURE_HELPER_BINARY_PATH.exists():
+                self._window_capture_helper_path = _WINDOW_CAPTURE_HELPER_BINARY_PATH
+                return _WINDOW_CAPTURE_HELPER_BINARY_PATH
+            helper_path = await ensure_csharp_helper(
+                source=_WINDOW_CAPTURE_HELPER_SOURCE,
+                source_path=_WINDOW_CAPTURE_HELPER_SOURCE_PATH,
+                output_path=_WINDOW_CAPTURE_HELPER_BINARY_PATH,
+                references=("System.Drawing.dll", "System.Runtime.Serialization.dll"),
+                timeout_seconds=self.timeout_seconds,
+                build_timeout_floor_seconds=_WINDOW_CAPTURE_HELPER_BUILD_TIMEOUT_FLOOR_SECONDS,
+                cancellation=cancellation,
+                unavailable_message="csc.exe is unavailable for Windows window capture",
+                timeout_message="Windows window capture helper build timed out",
+                failure_message="Windows window capture helper build failed",
+            )
+            self._window_capture_helper_path = helper_path
+            return helper_path
+
+    async def _capture_window(
+        self,
+        window_id: int,
+        cancellation: CancellationToken | None = None,
+    ) -> ConversationInlineDataPart:
+        helper_path = await self._ensure_window_capture_helper(cancellation=cancellation)
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as handle:
+            output_path = Path(handle.name)
+
+        try:
+            command = [
+                str(helper_path),
+                "--capture-window",
+                "--window-id",
+                str(window_id),
+                "--output-path",
+                str(output_path),
+            ]
+            if self.resize_max_edge_px is not None:
+                command.extend(["--max-edge-px", str(self.resize_max_edge_px)])
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    *command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, stderr = await communicate_with_cancellation(
+                    process=process,
+                    cancellation=cancellation,
+                    timeout_seconds=self.timeout_seconds,
+                )
+            except FileNotFoundError as exc:
+                raise RuntimeError("Windows window capture helper is unavailable") from exc
+            except asyncio.TimeoutError as exc:
+                raise RuntimeError("Windows window capture timed out") from exc
+            if process.returncode != 0:
+                stderr_text = stderr.decode("utf-8", errors="replace").strip() if stderr else ""
+                stdout_text = stdout.decode("utf-8", errors="replace").strip() if stdout else ""
+                detail_text = stderr_text or stdout_text
+                detail = f": {detail_text}" if detail_text else ""
+                raise RuntimeError(f"Windows window capture failed{detail}")
+            image_bytes = output_path.read_bytes()
+            if not image_bytes:
+                raise RuntimeError("Windows window capture produced an empty image")
+            return ConversationInlineDataPart(mime_type="image/png", data=image_bytes)
+        finally:
+            output_path.unlink(missing_ok=True)
+
+
+def _coerce_window_info(raw_window: dict[str, object]) -> _WindowsWindowInfo:
+    window_name = raw_window.get("windowName")
+    owner_name = raw_window.get("ownerName")
+    return _WindowsWindowInfo(
+        window_id=int(raw_window["windowID"]),
+        owner_name=str(owner_name or ""),
+        window_name=str(window_name) if window_name else None,
+        layer=int(raw_window.get("layer", 0)),
+    )
+
+
+def _select_window(
+    windows: tuple[_WindowsWindowInfo, ...],
+    target_name: str,
+) -> _WindowsWindowInfo | None:
+    normalized_target = _normalize_window_match_text(target_name)
+    if not normalized_target:
+        return None
+    for extractor in (
+        lambda window: window.window_name or "",
+        lambda window: window.owner_name,
+    ):
+        for window in windows:
+            if window.layer != 0:
+                continue
+            if normalized_target in _normalize_window_match_text(extractor(window)):
+                return window
+    return None
+
+
+def _normalize_window_match_text(value: str) -> str:
+    return " ".join(value.lower().split())

--- a/src/vocalive/util/windows_csharp.py
+++ b/src/vocalive/util/windows_csharp.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from vocalive.pipeline.interruption import CancellationToken
+
+
+_DEFAULT_CSC_CANDIDATES = (
+    Path(os.environ.get("WINDIR", r"C:\Windows"))
+    / "Microsoft.NET"
+    / "Framework64"
+    / "v4.0.30319"
+    / "csc.exe",
+    Path(os.environ.get("WINDIR", r"C:\Windows"))
+    / "Microsoft.NET"
+    / "Framework"
+    / "v4.0.30319"
+    / "csc.exe",
+)
+
+
+def find_csharp_compiler() -> str | None:
+    compiler = shutil.which("csc.exe") or shutil.which("csc")
+    if compiler:
+        return compiler
+    for candidate in _DEFAULT_CSC_CANDIDATES:
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+async def ensure_csharp_helper(
+    *,
+    source: str,
+    source_path: Path,
+    output_path: Path,
+    references: tuple[str, ...] = (),
+    timeout_seconds: float,
+    build_timeout_floor_seconds: float,
+    cancellation: CancellationToken | None = None,
+    unavailable_message: str,
+    timeout_message: str,
+    failure_message: str,
+) -> Path:
+    compiler = find_csharp_compiler()
+    if compiler is None:
+        raise RuntimeError(unavailable_message)
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text(source, encoding="utf-8")
+    with tempfile.NamedTemporaryFile(
+        dir=source_path.parent,
+        prefix=f"{output_path.stem}-",
+        suffix=output_path.suffix,
+        delete=False,
+    ) as handle:
+        temporary_output_path = Path(handle.name)
+    try:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                compiler,
+                "/nologo",
+                "/target:exe",
+                *(f"/r:{reference}" for reference in references),
+                f"/out:{temporary_output_path}",
+                str(source_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await communicate_with_cancellation(
+                process=process,
+                cancellation=cancellation,
+                timeout_seconds=max(timeout_seconds, build_timeout_floor_seconds),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(unavailable_message) from exc
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError(timeout_message) from exc
+        if process.returncode != 0:
+            stderr_text = stderr.decode("utf-8", errors="replace").strip() if stderr else ""
+            stdout_text = stdout.decode("utf-8", errors="replace").strip() if stdout else ""
+            detail_text = stderr_text or stdout_text
+            detail = f": {detail_text}" if detail_text else ""
+            raise RuntimeError(f"{failure_message}{detail}")
+        temporary_output_path.replace(output_path)
+        return output_path
+    finally:
+        temporary_output_path.unlink(missing_ok=True)
+
+
+async def communicate_with_cancellation(
+    process: asyncio.subprocess.Process,
+    cancellation: CancellationToken | None,
+    timeout_seconds: float,
+) -> tuple[bytes, bytes]:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    communicate_task = asyncio.create_task(process.communicate())
+    try:
+        while True:
+            if cancellation is not None:
+                cancellation.raise_if_cancelled()
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise asyncio.TimeoutError
+            done, _ = await asyncio.wait(
+                {communicate_task},
+                timeout=min(remaining, 0.1),
+            )
+            if communicate_task in done:
+                return await communicate_task
+    except BaseException:
+        await terminate_process(process)
+        if not communicate_task.done():
+            communicate_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await communicate_task
+        raise
+
+
+async def terminate_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    process.kill()
+    with contextlib.suppress(ProcessLookupError):
+        await process.wait()

--- a/tests/unit/test_audio_input.py
+++ b/tests/unit/test_audio_input.py
@@ -5,6 +5,7 @@ import math
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
@@ -12,7 +13,7 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from vocalive.audio.devices import resolve_input_device
-from vocalive.audio.input import CombinedAudioInput, UtteranceAccumulator
+from vocalive.audio.input import CombinedAudioInput, MicrophoneAudioInput, UtteranceAccumulator
 from vocalive.audio.speech_detection import AdaptiveEnergySpeechDetector
 from vocalive.models import AudioSegment
 from vocalive.audio.vad import FixedSilenceTurnDetector
@@ -220,7 +221,7 @@ class UtteranceAccumulatorTests(unittest.TestCase):
 
 
 class InputDeviceResolutionTests(unittest.TestCase):
-    def test_prefers_external_headset_when_default_is_builtin(self) -> None:
+    def test_keeps_default_when_only_external_candidate_is_hands_free(self) -> None:
         sounddevice = _FakeSounddevice(
             devices=[
                 {"name": "MacBook Pro Microphone", "max_input_channels": 1},
@@ -231,9 +232,25 @@ class InputDeviceResolutionTests(unittest.TestCase):
 
         match = resolve_input_device(sounddevice, requested_device=None, prefer_external=True)
 
-        self.assertEqual(match.index, 1)
+        self.assertEqual(match.index, 0)
+        self.assertEqual(match.selection, "default")
+        self.assertIn("MacBook Pro Microphone", match.label)
+
+    def test_prefers_usb_input_over_hands_free_when_default_is_builtin(self) -> None:
+        sounddevice = _FakeSounddevice(
+            devices=[
+                {"name": "MacBook Pro Microphone", "max_input_channels": 1},
+                {"name": "AirPods Pro Hands-Free", "max_input_channels": 1},
+                {"name": "USB Audio Interface", "max_input_channels": 1},
+            ],
+            default_input_index=0,
+        )
+
+        match = resolve_input_device(sounddevice, requested_device=None, prefer_external=True)
+
+        self.assertEqual(match.index, 2)
         self.assertEqual(match.selection, "external")
-        self.assertIn("AirPods Pro Hands-Free", match.label)
+        self.assertIn("USB Audio Interface", match.label)
 
     def test_keeps_system_default_when_it_is_already_external(self) -> None:
         sounddevice = _FakeSounddevice(
@@ -273,6 +290,92 @@ class InputDeviceResolutionTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "No external input device was found"):
             resolve_input_device(sounddevice, requested_device="external", prefer_external=True)
+
+    def test_explicit_external_can_still_select_hands_free_input(self) -> None:
+        sounddevice = _FakeSounddevice(
+            devices=[
+                {"name": "MacBook Pro Microphone", "max_input_channels": 1},
+                {"name": "AirPods Pro Hands-Free", "max_input_channels": 1},
+            ],
+            default_input_index=0,
+        )
+
+        match = resolve_input_device(sounddevice, requested_device="external", prefer_external=True)
+
+        self.assertEqual(match.index, 1)
+        self.assertEqual(match.selection, "external")
+        self.assertIn("AirPods Pro Hands-Free", match.label)
+
+
+class _FakeRawInputStream:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.callback = kwargs.get("callback")
+        self.started = False
+        self.stopped = False
+        self.closed = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeStreamingSounddevice(_FakeSounddevice):
+    def __init__(self, devices: list[dict[str, object]], default_input_index: int | None) -> None:
+        super().__init__(devices=devices, default_input_index=default_input_index)
+        self.streams: list[_FakeRawInputStream] = []
+
+    def RawInputStream(self, **kwargs) -> _FakeRawInputStream:
+        stream = _FakeRawInputStream(**kwargs)
+        self.streams.append(stream)
+        return stream
+
+
+class MicrophoneAudioInputTests(unittest.IsolatedAsyncioTestCase):
+    async def test_reads_microphone_chunks_via_callback_stream(self) -> None:
+        sounddevice = _FakeStreamingSounddevice(
+            devices=[
+                {"name": "Built-in Microphone", "max_input_channels": 1},
+            ],
+            default_input_index=0,
+        )
+        audio_input = MicrophoneAudioInput(
+            sample_rate_hz=1_000,
+            block_duration_ms=100.0,
+            speech_threshold=0.01,
+            speech_hold_ms=0.0,
+            silence_threshold_ms=100.0,
+            min_utterance_ms=100.0,
+        )
+
+        with patch("vocalive.audio.input._import_sounddevice", return_value=sounddevice):
+            selected_label = await audio_input.start()
+            self.assertEqual(selected_label, "Built-in Microphone (id=0)")
+            self.assertEqual(len(sounddevice.streams), 1)
+            stream = sounddevice.streams[0]
+            self.assertTrue(stream.started)
+            self.assertIsNotNone(stream.callback)
+            read_task = asyncio.create_task(audio_input.read())
+
+            assert stream.callback is not None
+            stream.callback(_pcm_chunk(frame_count=100, amplitude=2_000), 100, None, None)
+            stream.callback(_pcm_chunk(frame_count=100, amplitude=0), 100, None, None)
+
+            segment = await asyncio.wait_for(read_task, timeout=1.0)
+
+        self.assertIsNotNone(segment)
+        assert segment is not None
+        self.assertEqual(segment.sample_rate_hz, 1_000)
+        self.assertGreater(len(segment.pcm), 0)
+
+        await audio_input.close()
+        self.assertTrue(stream.stopped)
+        self.assertTrue(stream.closed)
 
 
 class _ScriptedAudioInput:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -28,6 +28,7 @@ from vocalive.llm.gemini import GeminiLanguageModel
 from vocalive.main import _run_microphone_loop, build_audio_input, build_orchestrator, build_overlay
 from vocalive.models import AudioSegment
 from vocalive.screen.macos import MacOSWindowScreenCapture
+from vocalive.screen.windows import WindowsWindowScreenCapture
 from vocalive.stt.moonshine import MoonshineSpeechToTextEngine
 from vocalive.tts.aivis import AivisSpeechTextToSpeechEngine
 from vocalive.ui.overlay import OverlayServer
@@ -112,8 +113,8 @@ class BuildOrchestratorTests(unittest.TestCase):
                 return None
 
         with patch("vocalive.main.sys.platform", "darwin"), patch(
-            "vocalive.main.MacOSApplicationAudioInput",
-            _FakeApplicationAudioInput,
+            "vocalive.main._application_audio_input_class_for_platform",
+            return_value=_FakeApplicationAudioInput,
         ):
             audio_input = build_audio_input(
                 AppSettings(
@@ -155,8 +156,8 @@ class BuildOrchestratorTests(unittest.TestCase):
                 return None
 
         with patch("vocalive.main.sys.platform", "darwin"), patch(
-            "vocalive.main.MacOSApplicationAudioInput",
-            _FakeApplicationAudioInput,
+            "vocalive.main._application_audio_input_class_for_platform",
+            return_value=_FakeApplicationAudioInput,
         ):
             build_audio_input(
                 AppSettings(
@@ -170,6 +171,21 @@ class BuildOrchestratorTests(unittest.TestCase):
 
         self.assertEqual(len(captured_kwargs), 1)
         self.assertTrue(captured_kwargs[0]["speech_start_events_enabled"])
+
+    def test_build_audio_input_supports_windows_application_audio(self) -> None:
+        with patch("vocalive.main.sys.platform", "win32"):
+            audio_input = build_audio_input(
+                AppSettings(
+                    application_audio=ApplicationAudioSettings(
+                        enabled=True,
+                        target="chrome",
+                    ),
+                )
+            )
+
+        self.assertIsNotNone(audio_input)
+        assert audio_input is not None
+        self.assertEqual(type(audio_input).__name__, "WindowsApplicationAudioInput")
 
     def test_build_orchestrator_can_disable_application_audio_enhancement(self) -> None:
         orchestrator = build_orchestrator(
@@ -220,6 +236,27 @@ class BuildOrchestratorTests(unittest.TestCase):
         self.assertEqual(orchestrator.screen_capture_engine.timeout_seconds, 7.0)
         self.assertEqual(orchestrator.screen_capture_engine.resize_max_edge_px, 960)
 
+    def test_build_orchestrator_enables_screen_capture_for_gemini_on_windows(self) -> None:
+        with patch("vocalive.main.sys.platform", "win32"):
+            orchestrator = build_orchestrator(
+                AppSettings(
+                    model_provider="gemini",
+                    screen_capture=ScreenCaptureSettings(
+                        enabled=True,
+                        window_name="Chrome",
+                        timeout_seconds=6.0,
+                        resize_max_edge_px=1024,
+                    ),
+                )
+            )
+
+        self.assertIsInstance(orchestrator.language_model, GeminiLanguageModel)
+        self.assertIsInstance(orchestrator.screen_capture_engine, WindowsWindowScreenCapture)
+        assert isinstance(orchestrator.screen_capture_engine, WindowsWindowScreenCapture)
+        self.assertEqual(orchestrator.screen_capture_engine.window_name, "Chrome")
+        self.assertEqual(orchestrator.screen_capture_engine.timeout_seconds, 6.0)
+        self.assertEqual(orchestrator.screen_capture_engine.resize_max_edge_px, 1024)
+
     def test_build_orchestrator_rejects_screen_capture_without_gemini(self) -> None:
         with self.assertRaisesRegex(
             ValueError,
@@ -241,6 +278,22 @@ class BuildOrchestratorTests(unittest.TestCase):
                     AppSettings(
                         model_provider="gemini",
                         screen_capture=ScreenCaptureSettings(enabled=True),
+                    )
+                )
+
+    def test_build_orchestrator_rejects_screen_capture_on_unsupported_platform(self) -> None:
+        with patch("vocalive.main.sys.platform", "linux"):
+            with self.assertRaisesRegex(
+                ValueError,
+                "screen capture input currently supports macOS and Windows only",
+            ):
+                build_orchestrator(
+                    AppSettings(
+                        model_provider="gemini",
+                        screen_capture=ScreenCaptureSettings(
+                            enabled=True,
+                            window_name="YouTube",
+                        ),
                     )
                 )
 

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from vocalive.audio.output import _default_playback_command
+
+
+class DefaultPlaybackCommandTests(unittest.TestCase):
+    def test_defaults_to_afplay_on_macos(self) -> None:
+        with patch("vocalive.audio.output.sys.platform", "darwin"), patch(
+            "vocalive.audio.output.shutil.which",
+            side_effect=lambda command: "/usr/bin/afplay" if command == "afplay" else None,
+        ):
+            command = _default_playback_command()
+
+        self.assertEqual(command, ["/usr/bin/afplay", "{path}"])
+
+    def test_defaults_to_powershell_soundplayer_on_windows(self) -> None:
+        with patch("vocalive.audio.output.sys.platform", "win32"), patch(
+            "vocalive.audio.output.shutil.which",
+            side_effect=lambda command: (
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+                if command == "powershell.exe"
+                else None
+            ),
+        ):
+            command = _default_playback_command()
+
+        self.assertEqual(
+            command,
+            [
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "(New-Object System.Media.SoundPlayer '{path}').PlaySync()",
+            ],
+        )
+
+    def test_raises_when_no_platform_default_is_available(self) -> None:
+        with patch("vocalive.audio.output.sys.platform", "linux"), patch(
+            "vocalive.audio.output.shutil.which",
+            return_value=None,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "speaker output requires a playback command"):
+                _default_playback_command()

--- a/tests/unit/test_screen_macos.py
+++ b/tests/unit/test_screen_macos.py
@@ -104,7 +104,7 @@ class MacOSWindowHelperTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(window_id, 42)
         create_subprocess_exec.assert_awaited_once_with(
-            "/tmp/vocalive-window-query",
+            str(Path("/tmp/vocalive-window-query")),
             stdout=unittest.mock.ANY,
             stderr=unittest.mock.ANY,
         )

--- a/tests/unit/test_screen_windows.py
+++ b/tests/unit/test_screen_windows.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, call, patch
+
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from vocalive.screen.windows import WindowsWindowScreenCapture, _WindowsWindowInfo, _select_window
+
+
+class WindowsWindowSelectionTests(unittest.TestCase):
+    def test_select_window_prefers_window_title_match(self) -> None:
+        windows = (
+            _WindowsWindowInfo(
+                window_id=11,
+                owner_name="chrome",
+                window_name="docs.google.com",
+                layer=0,
+            ),
+            _WindowsWindowInfo(
+                window_id=12,
+                owner_name="chrome",
+                window_name="YouTube - Google Chrome",
+                layer=0,
+            ),
+        )
+
+        selected = _select_window(windows, "YouTube")
+
+        self.assertEqual(selected, windows[1])
+
+    def test_select_window_falls_back_to_owner_name_match(self) -> None:
+        windows = (
+            _WindowsWindowInfo(
+                window_id=21,
+                owner_name="steam",
+                window_name=None,
+                layer=0,
+            ),
+        )
+
+        selected = _select_window(windows, "steam")
+
+        self.assertEqual(selected, windows[0])
+
+    def test_select_window_ignores_nonzero_window_layer(self) -> None:
+        windows = (
+            _WindowsWindowInfo(
+                window_id=31,
+                owner_name="chrome",
+                window_name="YouTube",
+                layer=3,
+            ),
+            _WindowsWindowInfo(
+                window_id=32,
+                owner_name="chrome",
+                window_name="YouTube",
+                layer=0,
+            ),
+        )
+
+        selected = _select_window(windows, "youtube")
+
+        self.assertEqual(selected, windows[1])
+
+
+class _StubProcess:
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
+
+
+class WindowsWindowHelperTests(unittest.IsolatedAsyncioTestCase):
+    async def test_resolve_window_id_uses_configured_timeout(self) -> None:
+        engine = WindowsWindowScreenCapture(window_name="Steam", timeout_seconds=3.5)
+        process = _StubProcess()
+
+        with (
+            patch.object(
+                engine,
+                "_ensure_window_capture_helper",
+                AsyncMock(return_value=Path("C:/tmp/vocalive-window-capture.exe")),
+            ),
+            patch(
+                "vocalive.screen.windows.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=process),
+            ) as create_subprocess_exec,
+            patch(
+                "vocalive.screen.windows.communicate_with_cancellation",
+                AsyncMock(
+                    return_value=(
+                        b'[{"windowID": 42, "ownerName": "steam", "windowName": "Steam", "layer": 0}]',
+                        b"",
+                    )
+                ),
+            ) as communicate,
+        ):
+            window_id = await engine._resolve_window_id()
+
+        self.assertEqual(window_id, 42)
+        create_subprocess_exec.assert_awaited_once_with(
+            str(Path("C:/tmp/vocalive-window-capture.exe")),
+            "--list-windows",
+            stdout=unittest.mock.ANY,
+            stderr=unittest.mock.ANY,
+        )
+        communicate.assert_awaited_once_with(
+            process=process,
+            cancellation=None,
+            timeout_seconds=3.5,
+        )
+
+    async def test_capture_window_passes_resize_arg_and_reads_output(self) -> None:
+        engine = WindowsWindowScreenCapture(
+            window_name="Steam",
+            timeout_seconds=3.5,
+            resize_max_edge_px=1024,
+        )
+        process = _StubProcess()
+
+        async def create_subprocess_exec(*args, **kwargs):
+            del kwargs
+            output_index = args.index("--output-path") + 1
+            Path(args[output_index]).write_bytes(b"png-data")
+            return process
+
+        with (
+            patch.object(
+                engine,
+                "_ensure_window_capture_helper",
+                AsyncMock(return_value=Path("C:/tmp/vocalive-window-capture.exe")),
+            ),
+            patch(
+                "vocalive.screen.windows.asyncio.create_subprocess_exec",
+                AsyncMock(side_effect=create_subprocess_exec),
+            ) as create_subprocess_exec_mock,
+            patch(
+                "vocalive.screen.windows.communicate_with_cancellation",
+                AsyncMock(return_value=(b"", b"")),
+            ) as communicate,
+        ):
+            screenshot = await engine._capture_window(window_id=42)
+
+        self.assertEqual(screenshot.mime_type, "image/png")
+        self.assertEqual(screenshot.data, b"png-data")
+        create_subprocess_exec_mock.assert_awaited_once()
+        self.assertIn(call(
+            str(Path("C:/tmp/vocalive-window-capture.exe")),
+            "--capture-window",
+            "--window-id",
+            "42",
+            "--output-path",
+            unittest.mock.ANY,
+            "--max-edge-px",
+            "1024",
+            stdout=unittest.mock.ANY,
+            stderr=unittest.mock.ANY,
+        ), create_subprocess_exec_mock.await_args_list)
+        communicate.assert_awaited_once_with(
+            process=process,
+            cancellation=None,
+            timeout_seconds=3.5,
+        )
+
+    async def test_window_capture_helper_build_is_cached(self) -> None:
+        engine = WindowsWindowScreenCapture(window_name="Steam", timeout_seconds=3.5)
+
+        with tempfile.TemporaryDirectory() as directory:
+            helper_dir = Path(directory)
+            source_path = helper_dir / "windows-window-capture.cs"
+            binary_path = helper_dir / "windows-window-capture.exe"
+
+            async def ensure_helper(**kwargs):
+                del kwargs
+                binary_path.write_bytes(b"binary")
+                return binary_path
+
+            with (
+                patch("vocalive.screen.windows._WINDOW_CAPTURE_HELPER_DIR", helper_dir),
+                patch("vocalive.screen.windows._WINDOW_CAPTURE_HELPER_SOURCE_PATH", source_path),
+                patch("vocalive.screen.windows._WINDOW_CAPTURE_HELPER_BINARY_PATH", binary_path),
+                patch(
+                    "vocalive.screen.windows.ensure_csharp_helper",
+                    AsyncMock(side_effect=ensure_helper),
+                ) as ensure_csharp_helper_mock,
+            ):
+                first_path = await engine._ensure_window_capture_helper()
+                second_path = await engine._ensure_window_capture_helper()
+
+        self.assertEqual(first_path, binary_path)
+        self.assertEqual(second_path, binary_path)
+        ensure_csharp_helper_mock.assert_awaited_once()

--- a/tests/unit/test_windows_application.py
+++ b/tests/unit/test_windows_application.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from vocalive.audio.windows_application import (
+    WindowsApplicationAudioInput,
+    _APPLICATION_AUDIO_HELPER_SOURCE,
+    _WindowsApplicationInfo,
+    _select_application,
+)
+
+
+class WindowsApplicationSelectionTests(unittest.TestCase):
+    def test_helper_source_uses_process_scoped_loopback(self) -> None:
+        self.assertIn(r'VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK = "VAD\\Process_Loopback"', _APPLICATION_AUDIO_HELPER_SOURCE)
+        self.assertIn(
+            "PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE",
+            _APPLICATION_AUDIO_HELPER_SOURCE,
+        )
+        self.assertNotIn("GetDefaultAudioEndpoint", _APPLICATION_AUDIO_HELPER_SOURCE)
+
+    def test_select_application_prefers_process_name_match(self) -> None:
+        applications = (
+            _WindowsApplicationInfo(
+                process_id=1,
+                application_name="chrome",
+                bundle_identifier=r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+                window_title="YouTube - Google Chrome",
+            ),
+            _WindowsApplicationInfo(
+                process_id=2,
+                application_name="steam",
+                bundle_identifier=r"C:\Program Files (x86)\Steam\steam.exe",
+                window_title="Steam",
+            ),
+        )
+
+        selected = _select_application(applications, "steam")
+
+        self.assertEqual(selected, applications[1])
+
+    def test_select_application_matches_executable_path(self) -> None:
+        applications = (
+            _WindowsApplicationInfo(
+                process_id=11,
+                application_name="chrome",
+                bundle_identifier=r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+                window_title="YouTube - Google Chrome",
+            ),
+        )
+
+        selected = _select_application(
+            applications,
+            r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+        )
+
+        self.assertEqual(selected, applications[0])
+
+    def test_select_application_falls_back_to_window_title_match(self) -> None:
+        applications = (
+            _WindowsApplicationInfo(
+                process_id=21,
+                application_name="chrome",
+                bundle_identifier=None,
+                window_title="YouTube - Google Chrome",
+            ),
+        )
+
+        selected = _select_application(applications, "YouTube")
+
+        self.assertEqual(selected, applications[0])
+
+
+class _StubProcess:
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
+
+
+class WindowsApplicationAudioInputTests(unittest.IsolatedAsyncioTestCase):
+    async def test_resolve_target_application_uses_helper_output(self) -> None:
+        audio_input = WindowsApplicationAudioInput(target="steam", timeout_seconds=4.0)
+        process = _StubProcess()
+
+        with (
+            patch(
+                "vocalive.audio.windows_application.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=process),
+            ) as create_subprocess_exec,
+            patch(
+                "vocalive.audio.windows_application.communicate_with_cancellation",
+                AsyncMock(
+                    return_value=(
+                        (
+                            b'[{"processId": 42, "applicationName": "steam", '
+                            b'"bundleIdentifier": "C:\\\\Steam\\\\steam.exe", '
+                            b'"windowTitle": "Steam"}]'
+                        ),
+                        b"",
+                    )
+                ),
+            ) as communicate,
+        ):
+            application = await audio_input._resolve_target_application(
+                Path("C:/tmp/windows-application-audio.exe")
+            )
+
+        self.assertEqual(application.process_id, 42)
+        self.assertEqual(application.application_name, "steam")
+        create_subprocess_exec.assert_awaited_once_with(
+            str(Path("C:/tmp/windows-application-audio.exe")),
+            "--list-applications",
+            stdout=unittest.mock.ANY,
+            stderr=unittest.mock.ANY,
+        )
+        communicate.assert_awaited_once_with(
+            process=process,
+            cancellation=None,
+            timeout_seconds=4.0,
+        )
+
+    async def test_ensure_process_uses_selected_process_id(self) -> None:
+        audio_input = WindowsApplicationAudioInput(target="steam", timeout_seconds=4.0)
+        selected_application = _WindowsApplicationInfo(
+            process_id=42,
+            application_name="steam",
+            bundle_identifier=r"C:\Steam\steam.exe",
+            window_title="Steam",
+        )
+        process = _StubProcess()
+
+        with (
+            patch.object(
+                audio_input,
+                "_ensure_helper",
+                AsyncMock(return_value=Path("C:/tmp/windows-application-audio.exe")),
+            ),
+            patch.object(
+                audio_input,
+                "_resolve_target_application",
+                AsyncMock(return_value=selected_application),
+            ),
+            patch.object(
+                audio_input,
+                "_drain_stderr",
+                AsyncMock(return_value=None),
+            ),
+            patch("vocalive.audio.windows_application.log_event") as log_event,
+            patch(
+                "vocalive.audio.windows_application.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=process),
+            ) as create_subprocess_exec,
+        ):
+            resolved_process = await audio_input._ensure_process()
+
+        self.assertIs(resolved_process, process)
+        self.assertEqual(audio_input._selected_application, selected_application)
+        self.assertEqual(audio_input._accumulator.segment_source_label, "steam")
+        create_subprocess_exec.assert_awaited_once_with(
+            str(Path("C:/tmp/windows-application-audio.exe")),
+            "--capture-audio",
+            "--process-id",
+            "42",
+            "--sample-rate-hz",
+            "16000",
+            "--channels",
+            "1",
+            stdout=unittest.mock.ANY,
+            stderr=unittest.mock.ANY,
+        )
+        log_event.assert_called_once_with(
+            unittest.mock.ANY,
+            "application_audio_stream_started",
+            application_name="steam",
+            executable_path=r"C:\Steam\steam.exe",
+            process_id=42,
+            window_title="Steam",
+            sample_rate_hz=16000,
+            channels=1,
+            speech_threshold=0.02,
+            adaptive_vad=True,
+            backend="windows_process_loopback",
+        )


### PR DESCRIPTION
## Summary
- add Windows application-audio capture, named-window screen capture, and default speaker playback support
- switch microphone streaming to a callback-backed queue and avoid auto-selecting low-fidelity hands-free microphone profiles
- remove audioop RMS usage and update tests plus docs for the Windows path

## Testing
- $testCommand

Closes #10