### PR TITLE
Add VOICEVOX as a selectable TTS provider

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -28,6 +28,7 @@ Current optional real adapters:
 - STT: `MoonshineSpeechToTextEngine`
 - LLM: `GeminiLanguageModel`
 - TTS: `AivisSpeechTextToSpeechEngine`
+- TTS: `VoicevoxTextToSpeechEngine`
 - Output: `SpeakerAudioOutput`
 
 Current optional presentation path:
@@ -42,7 +43,7 @@ Current hard constraints in the shipped app assembly:
 - application-audio capture currently requires `VOCALIVE_APP_AUDIO_TARGET`; macOS also requires Screen Recording permission, and Windows uses WASAPI process loopback for the selected process tree while the target process stays alive
 - Windows application-audio capture depends on `csc.exe` plus a Windows build with process-loopback support
 - screen capture currently supports macOS and Windows; macOS also requires Screen Recording permission
-- `VOCALIVE_OUTPUT_PROVIDER=speaker` currently requires `VOCALIVE_TTS_PROVIDER=aivis`
+- `VOCALIVE_OUTPUT_PROVIDER=speaker` currently requires `VOCALIVE_TTS_PROVIDER=aivis` or `voicevox`
 - speaker playback uses `afplay` by default on macOS and PowerShell `SoundPlayer` on Windows unless `VOCALIVE_SPEAKER_COMMAND` is set
 - the overlay is local browser UI only; it is driven by playback-chunk events rather than model token streaming
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The repository currently ships with:
 - optional live microphone capture via `sounddevice`
 - optional application-audio capture for one named running app on macOS or Windows
 - mock providers for end-to-end local testing
-- Moonshine STT, Gemini LLM, and AivisSpeech TTS adapters
+- Moonshine STT, Gemini LLM, AivisSpeech TTS, and VOICEVOX TTS adapters
 - in-memory output for tests and speaker playback through an external command
 - queue-based orchestration with bounded backlog, stale-turn cancellation, and latency logging
 
@@ -27,7 +27,7 @@ The repository currently ships with:
 - Implemented: Moonshine STT via `moonshine-voice`
 - Implemented: Gemini `generateContent` integration over HTTPS
 - Implemented: trigger-based named-window screenshot capture for Gemini input on macOS and Windows
-- Implemented: AivisSpeech synthesis over the local HTTP API
+- Implemented: AivisSpeech and VOICEVOX synthesis over local HTTP APIs
 - Implemented: default speaker playback via `afplay` on macOS and PowerShell `SoundPlayer` on Windows
 - Implemented: sentence-by-sentence TTS playback with one-sentence-ahead prefetch
 - Implemented: optional transparent browser overlay with a character image, speech-only captions, and per-chunk text reveal timed to playback
@@ -79,7 +79,7 @@ Install the optional voice dependencies when you want live microphone capture or
 python3 -m pip install -e '.[voice]'
 ```
 
-Run the full local voice path against Moonshine, Gemini, AivisSpeech, and speaker playback in explicit headless mode:
+Run the full local voice path against Moonshine, Gemini, AivisSpeech or VOICEVOX, and speaker playback in explicit headless mode:
 
 ```bash
 export VOCALIVE_INPUT_PROVIDER=microphone
@@ -109,7 +109,7 @@ Current runtime constraints:
 
 - live microphone or application-audio input currently requires `VOCALIVE_STT_PROVIDER=moonshine`
 - `VOCALIVE_APP_AUDIO_ENABLED=true` currently requires `VOCALIVE_APP_AUDIO_TARGET`; on macOS it also requires Screen Recording permission, and on Windows it requires `csc.exe` plus a Windows build with WASAPI process-loopback support
-- `VOCALIVE_OUTPUT_PROVIDER=speaker` currently requires `VOCALIVE_TTS_PROVIDER=aivis`
+- `VOCALIVE_OUTPUT_PROVIDER=speaker` currently requires `VOCALIVE_TTS_PROVIDER=aivis` or `voicevox`
 - `VOCALIVE_SCREEN_CAPTURE_ENABLED=true` currently requires `VOCALIVE_MODEL_PROVIDER=gemini`; on macOS it also requires Screen Recording permission, and on Windows it requires `csc.exe`
 - speaker playback uses `afplay {path}` by default on macOS and PowerShell `SoundPlayer` on Windows; on other platforms set `VOCALIVE_SPEAKER_COMMAND`
 - the overlay is local-only and driven by sentence playback events; it is not token streaming from the LLM
@@ -190,7 +190,7 @@ The controller UI exposes the same per-setting descriptions through each field's
 | `VOCALIVE_LOG_LEVEL` | `INFO` | Python logging level |
 | `VOCALIVE_STT_PROVIDER` | `mock` | STT adapter; accepts `moonshine` and aliases such as `moonshine voice` |
 | `VOCALIVE_MODEL_PROVIDER` | `mock` | LLM adapter; accepts `gemini` and aliases such as `google gemini` |
-| `VOCALIVE_TTS_PROVIDER` | `mock` | TTS adapter; accepts `aivis` and aliases such as `aivis speech` |
+| `VOCALIVE_TTS_PROVIDER` | `mock` | TTS adapter; accepts `aivis`, `voicevox`, and aliases such as `aivis speech` or `voice vox` |
 | `VOCALIVE_CONVERSATION_LANGUAGE` | `ja` | Per-turn language instruction injected before the LLM call; set empty to disable |
 | `VOCALIVE_USER_NAME` | unset | Optional user name injected before the LLM call so the assistant can answer who it is speaking with without defaulting to name-based greetings |
 | `VOCALIVE_CONTEXT_RECENT_MESSAGE_COUNT` | `8` | Number of recent user/assistant messages kept verbatim in Gemini requests before older dialogue is compacted |
@@ -260,6 +260,11 @@ The controller UI exposes the same per-setting descriptions through each field's
 | `VOCALIVE_AIVIS_SPEAKER_NAME` | unset | Speaker name to resolve via `/speakers` |
 | `VOCALIVE_AIVIS_STYLE_NAME` | unset | Style name to resolve via `/speakers` |
 | `VOCALIVE_AIVIS_TIMEOUT_SECONDS` | `30.0` | AivisSpeech API timeout |
+| `VOCALIVE_VOICEVOX_BASE_URL` | `http://127.0.0.1:50021` | VOICEVOX engine base URL |
+| `VOCALIVE_VOICEVOX_SPEAKER_ID` | unset | Explicit VOICEVOX style ID |
+| `VOCALIVE_VOICEVOX_SPEAKER_NAME` | unset | Speaker name to resolve via `/speakers` |
+| `VOCALIVE_VOICEVOX_STYLE_NAME` | unset | Style name to resolve via `/speakers` |
+| `VOCALIVE_VOICEVOX_TIMEOUT_SECONDS` | `30.0` | VOICEVOX API timeout |
 
 Current provider support:
 
@@ -275,10 +280,11 @@ Current provider support:
 - optional screen capture resolves a named on-screen window on macOS or Windows and attaches one PNG of that window to the current Gemini turn when an explicit trigger phrase or an eligible passive screen-reference phrase matches
 - older user/assistant dialogue is compacted into one bounded system summary before Gemini requests so long sessions do not resend the entire raw conversation every turn
 - `aivis` uses the local AivisSpeech engine API and resolves a style id from `/speakers` when needed
+- `voicevox` uses the local VOICEVOX engine API and resolves a style id from `/speakers` when needed
 - `speaker` output plays synthesized audio through the configured external command or the platform default playback command
 - `overlay` is an optional local browser UI fed by orchestrator events and chunk-level playback timing
 - the overlay loads character art from `src/vocalive/ui/assets/character.png` when present, and otherwise falls back to the built-in vector character
-- provider names are normalized case-insensitively, so values such as `Moonshine Voice` and `Aivis Speech` resolve to the supported adapters
+- provider names are normalized case-insensitively, so values such as `Moonshine Voice`, `Aivis Speech`, and `Voice Vox` resolve to the supported adapters
 
 ## Repository layout
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,7 @@ Optional real adapters:
 - `MacOSWindowScreenCapture`
 - `WindowsWindowScreenCapture`
 - `AivisSpeechTextToSpeechEngine`
+- `VoicevoxTextToSpeechEngine`
 - `SpeakerAudioOutput`
 
 Optional presentation path:
@@ -183,7 +184,7 @@ Current compatibility constraints:
 - application-audio input currently supports macOS and Windows
 - on macOS, application-audio capture depends on Screen Recording permission plus a first-run helper build
 - on Windows, application-audio capture depends on `csc.exe` plus a Windows build with WASAPI process-loopback support and isolates the selected process tree from other audible apps on the same device
-- speaker output is rejected unless TTS is `aivis`
+- speaker output is rejected unless TTS is `aivis` or `voicevox`
 - screen capture is rejected unless the model provider is `gemini`
 - screen capture is rejected unless `VOCALIVE_SCREEN_WINDOW_NAME` is configured
 - screen capture currently supports macOS and Windows and resolves the first on-screen window that matches the configured title or owner name

--- a/docs/development.md
+++ b/docs/development.md
@@ -125,7 +125,7 @@ Runtime settings are parsed through `AppSettings.from_mapping()` in `src/vocaliv
 | `VOCALIVE_APP_AUDIO_STT_ENHANCEMENT` | `true` | Enables lightweight application-audio speech enhancement before Moonshine STT |
 | `VOCALIVE_STT_PROVIDER` | `mock` | `moonshine` is supported; aliases such as `moonshine voice` are accepted |
 | `VOCALIVE_MODEL_PROVIDER` | `mock` | `gemini` is supported; aliases such as `google gemini` are accepted |
-| `VOCALIVE_TTS_PROVIDER` | `mock` | `aivis` is supported; aliases such as `aivis speech` are accepted |
+| `VOCALIVE_TTS_PROVIDER` | `mock` | `aivis` and `voicevox` are supported; aliases such as `aivis speech` and `voice vox` are accepted |
 | `VOCALIVE_OUTPUT_PROVIDER` | `memory` | `memory` or `speaker` |
 | `VOCALIVE_OVERLAY_ENABLED` | `false` | Starts the local transparent browser overlay with speech-only captions |
 | `VOCALIVE_OVERLAY_HOST` | `127.0.0.1` | Bind host/interface for the overlay server |
@@ -164,6 +164,11 @@ Runtime settings are parsed through `AppSettings.from_mapping()` in `src/vocaliv
 | `VOCALIVE_AIVIS_SPEAKER_NAME` | unset | Optional speaker name for `/speakers` lookup |
 | `VOCALIVE_AIVIS_STYLE_NAME` | unset | Optional style name for `/speakers` lookup |
 | `VOCALIVE_AIVIS_TIMEOUT_SECONDS` | `30` | AivisSpeech API timeout |
+| `VOCALIVE_VOICEVOX_BASE_URL` | `http://127.0.0.1:50021` | Local VOICEVOX engine base URL |
+| `VOCALIVE_VOICEVOX_SPEAKER_ID` | unset | Preferred explicit VOICEVOX style ID |
+| `VOCALIVE_VOICEVOX_SPEAKER_NAME` | unset | Optional speaker name for `/speakers` lookup |
+| `VOCALIVE_VOICEVOX_STYLE_NAME` | unset | Optional style name for `/speakers` lookup |
+| `VOCALIVE_VOICEVOX_TIMEOUT_SECONDS` | `30` | VOICEVOX API timeout |
 | `VOCALIVE_SPEAKER_COMMAND` | platform default | Override playback command; must include `{path}`. Defaults to `afplay {path}` on macOS and PowerShell `SoundPlayer` on Windows |
 | `VOCALIVE_QUEUE_MAXSIZE` | `4` | Bounded utterance backlog |
 | `VOCALIVE_QUEUE_OVERFLOW` | `drop_oldest` | `drop_oldest` or `reject_new` |
@@ -177,13 +182,13 @@ Useful working combinations today:
 1. Default local shell
    `python -m vocalive run` with `stdin` + `mock` STT + `mock` model + `mock` TTS + `memory`
 2. Real remote/local providers without microphone
-   `python -m vocalive run` with `stdin` + `moonshine` STT + `gemini` + `aivis` + `memory` or `speaker`
+   `python -m vocalive run` with `stdin` + `moonshine` STT + `gemini` + `aivis` or `voicevox` + `memory` or `speaker`
 3. Full live voice path
-   controller or `run` mode with `microphone` + `moonshine` + `gemini` + `aivis` + `speaker`
+   controller or `run` mode with `microphone` + `moonshine` + `gemini` + `aivis` or `voicevox` + `speaker`
 4. Live voice path with overlay
-   controller or `run` mode with `microphone` + `moonshine` + `gemini` + `aivis` + `speaker` + `VOCALIVE_OVERLAY_ENABLED=true`
+   controller or `run` mode with `microphone` + `moonshine` + `gemini` + `aivis` or `voicevox` + `speaker` + `VOCALIVE_OVERLAY_ENABLED=true`
 5. Game/video commentary path
-   `microphone` or `stdin` + `VOCALIVE_APP_AUDIO_ENABLED=true` + `moonshine` + `gemini` + `aivis` + `memory` or `speaker`
+   `microphone` or `stdin` + `VOCALIVE_APP_AUDIO_ENABLED=true` + `moonshine` + `gemini` + `aivis` or `voicevox` + `memory` or `speaker`
    default app-audio behavior is `VOCALIVE_APP_AUDIO_MODE=context_only`; set `VOCALIVE_APP_AUDIO_MODE=respond` only when immediate replies to app dialogue are desired
 
 Screen capture can be layered on combinations 2 and 3 when:

--- a/src/vocalive/config/settings.py
+++ b/src/vocalive/config/settings.py
@@ -29,6 +29,9 @@ _PROVIDER_ALIASES = {
         "aivisspeech": "aivis",
         "aivis speech": "aivis",
         "aivis tts": "aivis",
+        "voicevox": "voicevox",
+        "voice vox": "voicevox",
+        "voicevox tts": "voicevox",
     },
 }
 
@@ -138,7 +141,7 @@ CONTROLLER_SETTING_DEFINITIONS = (
         "providers",
         "enum",
         "mock",
-        options=("mock", "aivis"),
+        options=("mock", "aivis", "voicevox"),
     ),
     SettingDefinition("VOCALIVE_QUEUE_MAXSIZE", "queue", "int", "4"),
     SettingDefinition(
@@ -368,6 +371,16 @@ CONTROLLER_SETTING_DEFINITIONS = (
     SettingDefinition("VOCALIVE_AIVIS_SPEAKER_NAME", "aivis", "string", None, nullable=True),
     SettingDefinition("VOCALIVE_AIVIS_STYLE_NAME", "aivis", "string", None, nullable=True),
     SettingDefinition("VOCALIVE_AIVIS_TIMEOUT_SECONDS", "aivis", "float", "30.0"),
+    SettingDefinition(
+        "VOCALIVE_VOICEVOX_BASE_URL",
+        "voicevox",
+        "string",
+        "http://127.0.0.1:50021",
+    ),
+    SettingDefinition("VOCALIVE_VOICEVOX_SPEAKER_ID", "voicevox", "int", None, nullable=True),
+    SettingDefinition("VOCALIVE_VOICEVOX_SPEAKER_NAME", "voicevox", "string", None, nullable=True),
+    SettingDefinition("VOCALIVE_VOICEVOX_STYLE_NAME", "voicevox", "string", None, nullable=True),
+    SettingDefinition("VOCALIVE_VOICEVOX_TIMEOUT_SECONDS", "voicevox", "float", "30.0"),
 )
 
 _CONTROLLER_SETTING_INDEX = {
@@ -488,7 +501,10 @@ _CONTROLLER_SETTING_DOCUMENTATION = {
         description="LLM adapter; accepts `gemini` and aliases such as `google gemini`"
     ),
     "VOCALIVE_TTS_PROVIDER": SettingDocumentation(
-        description="TTS adapter; accepts `aivis` and aliases such as `aivis speech`"
+        description=(
+            "TTS adapter; accepts `aivis`, `voicevox`, and aliases such as "
+            "`aivis speech` or `voice vox`"
+        )
     ),
     "VOCALIVE_OUTPUT_PROVIDER": SettingDocumentation(description="`memory` or `speaker`"),
     "VOCALIVE_OVERLAY_ENABLED": SettingDocumentation(
@@ -630,6 +646,19 @@ _CONTROLLER_SETTING_DOCUMENTATION = {
     ),
     "VOCALIVE_AIVIS_TIMEOUT_SECONDS": SettingDocumentation(
         description="AivisSpeech API timeout"
+    ),
+    "VOCALIVE_VOICEVOX_BASE_URL": SettingDocumentation(description="VOICEVOX engine base URL"),
+    "VOCALIVE_VOICEVOX_SPEAKER_ID": SettingDocumentation(
+        description="Explicit VOICEVOX style ID"
+    ),
+    "VOCALIVE_VOICEVOX_SPEAKER_NAME": SettingDocumentation(
+        description="Speaker name to resolve via `/speakers`"
+    ),
+    "VOCALIVE_VOICEVOX_STYLE_NAME": SettingDocumentation(
+        description="Style name to resolve via `/speakers`"
+    ),
+    "VOCALIVE_VOICEVOX_TIMEOUT_SECONDS": SettingDocumentation(
+        description="VOICEVOX API timeout"
     ),
     "VOCALIVE_SPEAKER_COMMAND": SettingDocumentation(
         description=(
@@ -823,6 +852,15 @@ class AivisSpeechSettings:
 
 
 @dataclass
+class VoicevoxSettings:
+    base_url: str = "http://127.0.0.1:50021"
+    speaker_id: int | None = None
+    speaker_name: str | None = None
+    style_name: str | None = None
+    timeout_seconds: float = 30.0
+
+
+@dataclass
 class AppSettings:
     session_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     log_level: str = "INFO"
@@ -841,6 +879,7 @@ class AppSettings:
     screen_capture: ScreenCaptureSettings = field(default_factory=ScreenCaptureSettings)
     moonshine: MoonshineSettings = field(default_factory=MoonshineSettings)
     aivis: AivisSpeechSettings = field(default_factory=AivisSpeechSettings)
+    voicevox: VoicevoxSettings = field(default_factory=VoicevoxSettings)
 
     def __post_init__(self) -> None:
         self.stt_provider = _normalize_provider_setting("stt", self.stt_provider)
@@ -1225,6 +1264,29 @@ class AppSettings:
                 timeout_seconds=_read_float(
                     mapping,
                     "VOCALIVE_AIVIS_TIMEOUT_SECONDS",
+                    default=30.0,
+                ),
+            ),
+            voicevox=VoicevoxSettings(
+                base_url=_read_str_with_default(
+                    mapping,
+                    "VOCALIVE_VOICEVOX_BASE_URL",
+                    default="http://127.0.0.1:50021",
+                ),
+                speaker_id=_read_optional_int(mapping, "VOCALIVE_VOICEVOX_SPEAKER_ID"),
+                speaker_name=_read_optional_str_with_default(
+                    mapping,
+                    "VOCALIVE_VOICEVOX_SPEAKER_NAME",
+                    default=None,
+                ),
+                style_name=_read_optional_str_with_default(
+                    mapping,
+                    "VOCALIVE_VOICEVOX_STYLE_NAME",
+                    default=None,
+                ),
+                timeout_seconds=_read_float(
+                    mapping,
+                    "VOCALIVE_VOICEVOX_TIMEOUT_SECONDS",
                     default=30.0,
                 ),
             ),

--- a/src/vocalive/runtime.py
+++ b/src/vocalive/runtime.py
@@ -20,6 +20,7 @@ from vocalive.stt.mock import MockSpeechToTextEngine
 from vocalive.stt.moonshine import MoonshineSpeechToTextEngine
 from vocalive.tts.aivis import AivisSpeechTextToSpeechEngine
 from vocalive.tts.mock import MockTextToSpeechEngine
+from vocalive.tts.voicevox import VoicevoxTextToSpeechEngine
 from vocalive.ui.overlay import OverlayServer
 from vocalive.util.logging import get_logger, log_event
 
@@ -86,12 +87,20 @@ def build_orchestrator(
             style_name=settings.aivis.style_name,
             timeout_seconds=settings.aivis.timeout_seconds,
         )
+    elif settings.tts_provider == "voicevox":
+        tts_engine = VoicevoxTextToSpeechEngine(
+            base_url=settings.voicevox.base_url,
+            speaker_id=settings.voicevox.speaker_id,
+            speaker_name=settings.voicevox.speaker_name,
+            style_name=settings.voicevox.style_name,
+            timeout_seconds=settings.voicevox.timeout_seconds,
+        )
     else:
         tts_engine = MockTextToSpeechEngine()
     if settings.output.provider == OutputProvider.SPEAKER:
-        if settings.tts_provider != "aivis":
+        if settings.tts_provider not in {"aivis", "voicevox"}:
             raise ValueError(
-                "speaker output currently requires VOCALIVE_TTS_PROVIDER=aivis"
+                "speaker output currently requires VOCALIVE_TTS_PROVIDER=aivis or voicevox"
             )
         audio_output = SpeakerAudioOutput(
             playback_command=parse_playback_command(settings.output.speaker_command)

--- a/src/vocalive/tts/aivis.py
+++ b/src/vocalive/tts/aivis.py
@@ -1,21 +1,18 @@
 from __future__ import annotations
 
-import asyncio
-import json
-import urllib.error
-import urllib.parse
-import urllib.request
-import wave
-from io import BytesIO
 from typing import Any
 
-from vocalive.models import SynthesizedSpeech, TurnContext
-from vocalive.pipeline.interruption import CancellationToken
-from vocalive.tts.base import TextToSpeechEngine
+from vocalive.tts.style_api import (
+    HttpStyleTextToSpeechEngine,
+    _read_wave_duration_ms,
+    _read_wave_metadata,
+    _select_style as _shared_select_style,
+)
 
 
-class AivisSpeechTextToSpeechEngine(TextToSpeechEngine):
+class AivisSpeechTextToSpeechEngine(HttpStyleTextToSpeechEngine):
     name = "aivisspeech"
+    provider_label = "AivisSpeech"
 
     def __init__(
         self,
@@ -25,89 +22,13 @@ class AivisSpeechTextToSpeechEngine(TextToSpeechEngine):
         style_name: str | None = None,
         timeout_seconds: float = 30.0,
     ) -> None:
-        self.base_url = base_url.rstrip("/")
-        self.speaker_id = speaker_id
-        self.speaker_name = speaker_name
-        self.style_name = style_name
-        self.timeout_seconds = timeout_seconds
-        self._resolved_speaker_id: int | None = speaker_id
-
-    async def synthesize(
-        self,
-        text: str,
-        context: TurnContext,
-        cancellation: CancellationToken | None = None,
-    ) -> SynthesizedSpeech:
-        if cancellation is not None:
-            cancellation.raise_if_cancelled()
-        speaker_id = await asyncio.to_thread(self._resolve_speaker_id)
-        audio_query = await asyncio.to_thread(self._request_audio_query, text, speaker_id)
-        if cancellation is not None:
-            cancellation.raise_if_cancelled()
-        audio_bytes = await asyncio.to_thread(self._request_synthesis, audio_query, speaker_id)
-        if cancellation is not None:
-            cancellation.raise_if_cancelled()
-        sample_rate_hz, channels, sample_width_bytes = _read_wave_metadata(audio_bytes)
-        duration_ms = _read_wave_duration_ms(audio_bytes)
-        return SynthesizedSpeech(
-            text=text,
-            provider=self.name,
-            audio=audio_bytes,
-            sample_rate_hz=sample_rate_hz,
-            channels=channels,
-            sample_width_bytes=sample_width_bytes,
-            duration_ms=duration_ms,
-            mime_type="audio/wav",
-            file_extension=".wav",
+        super().__init__(
+            base_url=base_url,
+            speaker_id=speaker_id,
+            speaker_name=speaker_name,
+            style_name=style_name,
+            timeout_seconds=timeout_seconds,
         )
-
-    def _resolve_speaker_id(self) -> int:
-        if self._resolved_speaker_id is not None:
-            return self._resolved_speaker_id
-        speakers = self._get_json("/speakers")
-        if not isinstance(speakers, list) or not speakers:
-            raise RuntimeError("AivisSpeech returned no speakers from /speakers")
-        matching_style = _select_style(
-            speakers=speakers,
-            speaker_name=self.speaker_name,
-            style_name=self.style_name,
-        )
-        self._resolved_speaker_id = matching_style
-        return matching_style
-
-    def _request_audio_query(self, text: str, speaker_id: int) -> dict[str, Any]:
-        query = urllib.parse.urlencode({"text": text, "speaker": speaker_id})
-        response = self._post_json(f"/audio_query?{query}", payload=None)
-        if not isinstance(response, dict):
-            raise RuntimeError(f"AivisSpeech returned an invalid audio query: {response!r}")
-        return response
-
-    def _request_synthesis(self, audio_query: dict[str, Any], speaker_id: int) -> bytes:
-        query = urllib.parse.urlencode({"speaker": speaker_id})
-        return self._post_bytes(f"/synthesis?{query}", payload=audio_query)
-
-    def _get_json(self, path: str) -> Any:
-        request = urllib.request.Request(url=f"{self.base_url}{path}", method="GET")
-        return _open_json(request=request, timeout_seconds=self.timeout_seconds)
-
-    def _post_json(self, path: str, payload: dict[str, Any] | None) -> Any:
-        body = b"" if payload is None else json.dumps(payload).encode("utf-8")
-        request = urllib.request.Request(
-            url=f"{self.base_url}{path}",
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        return _open_json(request=request, timeout_seconds=self.timeout_seconds)
-
-    def _post_bytes(self, path: str, payload: dict[str, Any]) -> bytes:
-        request = urllib.request.Request(
-            url=f"{self.base_url}{path}",
-            data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        return _open_bytes(request=request, timeout_seconds=self.timeout_seconds)
 
 
 def _select_style(
@@ -115,89 +36,9 @@ def _select_style(
     speaker_name: str | None,
     style_name: str | None,
 ) -> int:
-    speaker_name_normalized = speaker_name.strip() if speaker_name else None
-    style_name_normalized = style_name.strip() if style_name else None
-    first_style_id: int | None = None
-    speaker_found = False
-
-    for speaker in speakers:
-        if not isinstance(speaker, dict):
-            continue
-        current_speaker_name = speaker.get("name")
-        styles = speaker.get("styles")
-        if not isinstance(styles, list):
-            continue
-        candidate_style_ids = []
-        for style in styles:
-            if not isinstance(style, dict):
-                continue
-            style_id = style.get("id", style.get("style_id"))
-            if not isinstance(style_id, int):
-                continue
-            if first_style_id is None:
-                first_style_id = style_id
-            candidate_style_ids.append((style_id, style.get("name")))
-        if speaker_name_normalized and current_speaker_name != speaker_name_normalized:
-            continue
-        if speaker_name_normalized:
-            speaker_found = True
-        for style_id, current_style_name in candidate_style_ids:
-            if style_name_normalized is None or current_style_name == style_name_normalized:
-                return style_id
-
-    if speaker_name_normalized and not speaker_found:
-        raise RuntimeError(f"AivisSpeech speaker not found: {speaker_name_normalized}")
-    if style_name_normalized:
-        raise RuntimeError(
-            "AivisSpeech style not found. "
-            f"speaker={speaker_name_normalized!r} style={style_name_normalized!r}"
-        )
-    if first_style_id is not None:
-        return first_style_id
-    raise RuntimeError(
-        "Could not resolve an AivisSpeech style ID from /speakers. "
-        "Set VOCALIVE_AIVIS_SPEAKER_ID or provide matching speaker/style names."
+    return _shared_select_style(
+        speakers=speakers,
+        speaker_name=speaker_name,
+        style_name=style_name,
+        provider_label="AivisSpeech",
     )
-
-
-def _open_json(request: urllib.request.Request, timeout_seconds: float) -> Any:
-    try:
-        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        raw_body = exc.read().decode("utf-8", errors="replace")
-        raise RuntimeError(
-            f"AivisSpeech API request failed with status {exc.code}: {raw_body}"
-        ) from exc
-    except urllib.error.URLError as exc:
-        raise RuntimeError(f"AivisSpeech API request failed: {exc.reason}") from exc
-
-
-def _open_bytes(request: urllib.request.Request, timeout_seconds: float) -> bytes:
-    try:
-        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
-            return response.read()
-    except urllib.error.HTTPError as exc:
-        raw_body = exc.read().decode("utf-8", errors="replace")
-        raise RuntimeError(
-            f"AivisSpeech API request failed with status {exc.code}: {raw_body}"
-        ) from exc
-    except urllib.error.URLError as exc:
-        raise RuntimeError(f"AivisSpeech API request failed: {exc.reason}") from exc
-
-
-def _read_wave_metadata(audio_bytes: bytes) -> tuple[int, int, int]:
-    with wave.open(BytesIO(audio_bytes), "rb") as wav_file:
-        return (
-            wav_file.getframerate(),
-            wav_file.getnchannels(),
-            wav_file.getsampwidth(),
-        )
-
-
-def _read_wave_duration_ms(audio_bytes: bytes) -> float:
-    with wave.open(BytesIO(audio_bytes), "rb") as wav_file:
-        frame_rate = wav_file.getframerate()
-        if frame_rate <= 0:
-            raise RuntimeError("AivisSpeech returned invalid WAV metadata: frame rate must be > 0")
-        return (wav_file.getnframes() / frame_rate) * 1000.0

--- a/src/vocalive/tts/style_api.py
+++ b/src/vocalive/tts/style_api.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+import wave
+from io import BytesIO
+from typing import Any
+
+from vocalive.models import SynthesizedSpeech, TurnContext
+from vocalive.pipeline.interruption import CancellationToken
+from vocalive.tts.base import TextToSpeechEngine
+
+
+class HttpStyleTextToSpeechEngine(TextToSpeechEngine):
+    name = "style-api-tts"
+    provider_label = "TTS"
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        speaker_id: int | None = None,
+        speaker_name: str | None = None,
+        style_name: str | None = None,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.speaker_id = speaker_id
+        self.speaker_name = speaker_name
+        self.style_name = style_name
+        self.timeout_seconds = timeout_seconds
+        self._resolved_speaker_id: int | None = speaker_id
+
+    async def synthesize(
+        self,
+        text: str,
+        context: TurnContext,
+        cancellation: CancellationToken | None = None,
+    ) -> SynthesizedSpeech:
+        del context
+        if cancellation is not None:
+            cancellation.raise_if_cancelled()
+        speaker_id = await asyncio.to_thread(self._resolve_speaker_id)
+        audio_query = await asyncio.to_thread(self._request_audio_query, text, speaker_id)
+        if cancellation is not None:
+            cancellation.raise_if_cancelled()
+        audio_bytes = await asyncio.to_thread(self._request_synthesis, audio_query, speaker_id)
+        if cancellation is not None:
+            cancellation.raise_if_cancelled()
+        sample_rate_hz, channels, sample_width_bytes = _read_wave_metadata(audio_bytes)
+        duration_ms = _read_wave_duration_ms(audio_bytes)
+        return SynthesizedSpeech(
+            text=text,
+            provider=self.name,
+            audio=audio_bytes,
+            sample_rate_hz=sample_rate_hz,
+            channels=channels,
+            sample_width_bytes=sample_width_bytes,
+            duration_ms=duration_ms,
+            mime_type="audio/wav",
+            file_extension=".wav",
+        )
+
+    def _resolve_speaker_id(self) -> int:
+        if self._resolved_speaker_id is not None:
+            return self._resolved_speaker_id
+        speakers = self._get_json("/speakers")
+        if not isinstance(speakers, list) or not speakers:
+            raise RuntimeError(f"{self.provider_label} returned no speakers from /speakers")
+        matching_style = _select_style(
+            speakers=speakers,
+            speaker_name=self.speaker_name,
+            style_name=self.style_name,
+            provider_label=self.provider_label,
+        )
+        self._resolved_speaker_id = matching_style
+        return matching_style
+
+    def _request_audio_query(self, text: str, speaker_id: int) -> dict[str, Any]:
+        query = urllib.parse.urlencode({"text": text, "speaker": speaker_id})
+        response = self._post_json(f"/audio_query?{query}", payload=None)
+        if not isinstance(response, dict):
+            raise RuntimeError(
+                f"{self.provider_label} returned an invalid audio query: {response!r}"
+            )
+        return response
+
+    def _request_synthesis(self, audio_query: dict[str, Any], speaker_id: int) -> bytes:
+        query = urllib.parse.urlencode({"speaker": speaker_id})
+        return self._post_bytes(f"/synthesis?{query}", payload=audio_query)
+
+    def _get_json(self, path: str) -> Any:
+        request = urllib.request.Request(url=f"{self.base_url}{path}", method="GET")
+        return self._open_json(request=request)
+
+    def _post_json(self, path: str, payload: dict[str, Any] | None) -> Any:
+        body = b"" if payload is None else json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            url=f"{self.base_url}{path}",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        return self._open_json(request=request)
+
+    def _post_bytes(self, path: str, payload: dict[str, Any]) -> bytes:
+        request = urllib.request.Request(
+            url=f"{self.base_url}{path}",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        return self._open_bytes(request=request)
+
+    def _open_json(self, request: urllib.request.Request) -> Any:
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            raw_body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"{self.provider_label} API request failed with status {exc.code}: {raw_body}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"{self.provider_label} API request failed: {exc.reason}") from exc
+
+    def _open_bytes(self, request: urllib.request.Request) -> bytes:
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                return response.read()
+        except urllib.error.HTTPError as exc:
+            raw_body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"{self.provider_label} API request failed with status {exc.code}: {raw_body}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"{self.provider_label} API request failed: {exc.reason}") from exc
+
+
+def _select_style(
+    speakers: list[Any],
+    speaker_name: str | None,
+    style_name: str | None,
+    provider_label: str = "TTS",
+) -> int:
+    speaker_name_normalized = speaker_name.strip() if speaker_name else None
+    style_name_normalized = style_name.strip() if style_name else None
+    first_style_id: int | None = None
+    speaker_found = False
+
+    for speaker in speakers:
+        if not isinstance(speaker, dict):
+            continue
+        current_speaker_name = speaker.get("name")
+        styles = speaker.get("styles")
+        if not isinstance(styles, list):
+            continue
+        candidate_style_ids = []
+        for style in styles:
+            if not isinstance(style, dict):
+                continue
+            style_id = style.get("id", style.get("style_id"))
+            if not isinstance(style_id, int):
+                continue
+            if first_style_id is None:
+                first_style_id = style_id
+            candidate_style_ids.append((style_id, style.get("name")))
+        if speaker_name_normalized and current_speaker_name != speaker_name_normalized:
+            continue
+        if speaker_name_normalized:
+            speaker_found = True
+        for style_id, current_style_name in candidate_style_ids:
+            if style_name_normalized is None or current_style_name == style_name_normalized:
+                return style_id
+
+    if speaker_name_normalized and not speaker_found:
+        raise RuntimeError(f"{provider_label} speaker not found: {speaker_name_normalized}")
+    if style_name_normalized:
+        raise RuntimeError(
+            f"{provider_label} style not found. "
+            f"speaker={speaker_name_normalized!r} style={style_name_normalized!r}"
+        )
+    if first_style_id is not None:
+        return first_style_id
+    raise RuntimeError(
+        f"Could not resolve a {provider_label} style ID from /speakers. "
+        "Set an explicit speaker ID or provide matching speaker/style names."
+    )
+
+
+def _read_wave_metadata(audio_bytes: bytes) -> tuple[int, int, int]:
+    with wave.open(BytesIO(audio_bytes), "rb") as wav_file:
+        return (
+            wav_file.getframerate(),
+            wav_file.getnchannels(),
+            wav_file.getsampwidth(),
+        )
+
+
+def _read_wave_duration_ms(audio_bytes: bytes) -> float:
+    with wave.open(BytesIO(audio_bytes), "rb") as wav_file:
+        frame_rate = wav_file.getframerate()
+        if frame_rate <= 0:
+            raise RuntimeError("TTS engine returned invalid WAV metadata: frame rate must be > 0")
+        return (wav_file.getnframes() / frame_rate) * 1000.0

--- a/src/vocalive/tts/voicevox.py
+++ b/src/vocalive/tts/voicevox.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from vocalive.tts.style_api import HttpStyleTextToSpeechEngine
+
+
+class VoicevoxTextToSpeechEngine(HttpStyleTextToSpeechEngine):
+    name = "voicevox"
+    provider_label = "VOICEVOX"
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:50021",
+        speaker_id: int | None = None,
+        speaker_name: str | None = None,
+        style_name: str | None = None,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        super().__init__(
+            base_url=base_url,
+            speaker_id=speaker_id,
+            speaker_name=speaker_name,
+            style_name=style_name,
+            timeout_seconds=timeout_seconds,
+        )

--- a/src/vocalive/ui/controller.py
+++ b/src/vocalive/ui/controller.py
@@ -502,6 +502,7 @@ _PAGE_TEMPLATE = """
       screen_capture: "Screen Capture",
       moonshine: "Moonshine",
       aivis: "Aivis",
+      voicevox: "VOICEVOX",
     };
 
     const groupsRoot = document.getElementById("groups");

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -22,6 +22,8 @@ from vocalive.config.settings import (
     InputProvider,
     InputSettings,
     OverlaySettings,
+    OutputProvider,
+    OutputSettings,
     ScreenCaptureSettings,
 )
 from vocalive.llm.gemini import GeminiLanguageModel
@@ -38,6 +40,7 @@ from vocalive.screen.macos import MacOSWindowScreenCapture
 from vocalive.screen.windows import WindowsWindowScreenCapture
 from vocalive.stt.moonshine import MoonshineSpeechToTextEngine
 from vocalive.tts.aivis import AivisSpeechTextToSpeechEngine
+from vocalive.tts.voicevox import VoicevoxTextToSpeechEngine
 from vocalive.ui.overlay import OverlayServer
 
 
@@ -66,6 +69,23 @@ class BuildOrchestratorTests(unittest.TestCase):
         self.assertEqual(orchestrator.language_model.thinking_budget, 0)
         self.assertIsInstance(orchestrator.tts_engine, AivisSpeechTextToSpeechEngine)
         self.assertIsInstance(orchestrator.audio_output, MemoryAudioOutput)
+
+    def test_build_orchestrator_supports_voicevox_tts_with_speaker_output(self) -> None:
+        orchestrator = build_orchestrator(
+            AppSettings(
+                tts_provider="VOICEVOX",
+                output=OutputSettings(
+                    provider=OutputProvider.SPEAKER,
+                    speaker_command="playback {path}",
+                ),
+            )
+        )
+
+        self.assertIsInstance(orchestrator.tts_engine, VoicevoxTextToSpeechEngine)
+        self.assertEqual(
+            orchestrator.audio_output.playback_command,
+            ("playback", "{path}"),
+        )
 
     def test_build_audio_input_propagates_device_preferences(self) -> None:
         audio_input = build_audio_input(

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -63,6 +63,18 @@ class AppSettingsTests(unittest.TestCase):
         self.assertEqual(settings.model_provider, "gemini")
         self.assertEqual(settings.tts_provider, "aivis")
 
+    def test_from_env_normalizes_voicevox_alias(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "VOCALIVE_TTS_PROVIDER": "Voice Vox",
+            },
+            clear=True,
+        ):
+            settings = AppSettings.from_env()
+
+        self.assertEqual(settings.tts_provider, "voicevox")
+
     def test_from_env_rejects_unknown_provider_names(self) -> None:
         with patch.dict(os.environ, {"VOCALIVE_TTS_PROVIDER": "unsupported"}, clear=True):
             with self.assertRaisesRegex(ValueError, "Unsupported tts provider"):
@@ -435,6 +447,11 @@ class AppSettingsTests(unittest.TestCase):
             "VOCALIVE_AIVIS_SPEAKER_NAME",
             "VOCALIVE_AIVIS_STYLE_NAME",
             "VOCALIVE_AIVIS_TIMEOUT_SECONDS",
+            "VOCALIVE_VOICEVOX_BASE_URL",
+            "VOCALIVE_VOICEVOX_SPEAKER_ID",
+            "VOCALIVE_VOICEVOX_SPEAKER_NAME",
+            "VOCALIVE_VOICEVOX_STYLE_NAME",
+            "VOCALIVE_VOICEVOX_TIMEOUT_SECONDS",
         }
 
         actual_names = {


### PR DESCRIPTION
## Summary
- add a shared local HTTP style-API TTS base and a VOICEVOX adapter
- add `voicevox` provider settings and controller support
- allow speaker output with `VOCALIVE_TTS_PROVIDER=voicevox`
- update tests and documentation

Closes #14